### PR TITLE
Adding .ts file for de_DE locale

### DIFF
--- a/i18n/de.ts
+++ b/i18n/de.ts
@@ -1,0 +1,3330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE" sourcelanguage="en_US">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../src/dialogs/aboutdialog.ui" line="17"/>
+        <source>About</source>
+        <translation>Über</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/aboutdialog.ui" line="114"/>
+        <source>Version:
+ </source>
+        <translation>Version:
+ </translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/aboutdialog.cpp" line="25"/>
+        <source>Version: %1</source>
+        <translation>Version: %1</translation>
+    </message>
+</context>
+<context>
+    <name>AddBorderDialog</name>
+    <message>
+        <location filename="../src/dialogs/addborderdialog.ui" line="23"/>
+        <source>Add border</source>
+        <translation>Rand hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/addborderdialog.ui" line="69"/>
+        <source>Color</source>
+        <translation>Farbe</translation>
+    </message>
+</context>
+<context>
+    <name>BatchDialog</name>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="17"/>
+        <source>Batch conversion</source>
+        <translation>Batch-/Stapel-Konvertierung</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="32"/>
+        <source>Input files</source>
+        <translation>Dateien hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="46"/>
+        <source>Add all from current directory</source>
+        <translation>Alle aus aktuellem Verzeichnis hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="53"/>
+        <source>Add files</source>
+        <translation>Dateien hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="60"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="554"/>
+        <source>Remove</source>
+        <translation>Entfernen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="67"/>
+        <source>Remove all</source>
+        <translation>Alle entfernen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="129"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="464"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="470"/>
+        <source>Preview</source>
+        <translation>Vorschau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="185"/>
+        <source>Conversions</source>
+        <translation>Batch-/Stapel-Konvertierung</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="192"/>
+        <source>Crop</source>
+        <translation>Beschneiden</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="257"/>
+        <source>Rotate</source>
+        <translation>Drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="269"/>
+        <source>Rotate right</source>
+        <translation>Nach rechts drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="274"/>
+        <source>Rotate left</source>
+        <translation>Nach links drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="279"/>
+        <source>Rotate 180</source>
+        <translation>Um 180° drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="293"/>
+        <source>if</source>
+        <translation>wenn</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="301"/>
+        <source>Always</source>
+        <translation>Immer</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="306"/>
+        <source>Landscape</source>
+        <translation>Querformat</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="311"/>
+        <source>Portrait</source>
+        <translation>Hochformat</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="337"/>
+        <source>Horizontal flip</source>
+        <translation>Horizontal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="344"/>
+        <source>Vertical flip</source>
+        <translation>Vertikal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="351"/>
+        <source>Auto color adjust</source>
+        <translation>Farbe automatisch anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="358"/>
+        <source>Sharpen</source>
+        <translation>Schärfen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="365"/>
+        <source>Grayscale</source>
+        <translation>Graustufen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="372"/>
+        <source>Negative</source>
+        <translation>Negativ</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="379"/>
+        <source>Resize</source>
+        <translation>Größe ändern</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="391"/>
+        <source>New width</source>
+        <translation>Neue Breite</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="396"/>
+        <source>New height</source>
+        <translation>Neue Höhe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="401"/>
+        <source>Long side</source>
+        <translation>Lange Seite</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="406"/>
+        <source>Short side</source>
+        <translation>Kurze Seite</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="411"/>
+        <source>Scale to</source>
+        <translation>Skalieren</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="416"/>
+        <source>New size</source>
+        <translation>Neue Größe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="456"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="478"/>
+        <source>x</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="490"/>
+        <source>Method:</source>
+        <translation>Methode:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="522"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="575"/>
+        <source>Effects</source>
+        <translation>Effekte</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="547"/>
+        <source>Add effect</source>
+        <translation>Effekt hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="584"/>
+        <source>Output directory</source>
+        <translation>Ausgabeverzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="590"/>
+        <source>Select directory</source>
+        <translation>Verzeichnis auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="603"/>
+        <source>Rename</source>
+        <translation>Umbenennen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="614"/>
+        <source>Pattern</source>
+        <translation>Muster</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="626"/>
+        <source>(special characters are: &apos;@&apos; for original file name without extension, &apos;#&apos; for counter digits)</source>
+        <translation>(Sonderzeichen: &apos;@&apos; für urspringlichen Dateiname ohne Dateiendung, &apos;#&apos; für Zähler)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="635"/>
+        <source>Counter start</source>
+        <translation>Start-Zähler</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="649"/>
+        <source>increment</source>
+        <translation>Erhöhung</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="683"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="707"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="731"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="755"/>
+        <source>Replace</source>
+        <translation>Ersetzen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="693"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="717"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="741"/>
+        <location filename="../src/dialogs/batchdialog.ui" line="765"/>
+        <source>with</source>
+        <translation>mit</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="780"/>
+        <source>Convert</source>
+        <translation>Konvertierung</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="791"/>
+        <source>Threads</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="805"/>
+        <source>(0 == auto)</source>
+        <translation>(0 = automatisch)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="853"/>
+        <source>Progress</source>
+        <translation>Fortschritt</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="898"/>
+        <source>Back</source>
+        <translation>Zurück</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="905"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="185"/>
+        <source>Next</source>
+        <translation>Weiter</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.ui" line="928"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="910"/>
+        <source>Close</source>
+        <translation>Schließen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="189"/>
+        <source>Start</source>
+        <translation>Starten</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="239"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="244"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="250"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="446"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="493"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="508"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="239"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="493"/>
+        <source>Empty input file list.</source>
+        <translation>Eingangs-Dateiliste leeren.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="244"/>
+        <source>At least one of the Rename / Convert options have to be selected.</source>
+        <translation type="unfinished">Mindestens eine der Umbenennen / Umwandeln Optionen muß ausgewählt werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="250"/>
+        <source>No valid target directory provided.</source>
+        <translation>Kein gültiges Zielverzeichnis angegeben.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="262"/>
+        <source>Abort</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="293"/>
+        <source>All supported images</source>
+        <translation>Alle unterstützten Bilder</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="306"/>
+        <source>All files</source>
+        <translation>Alle Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="309"/>
+        <source>Open File</source>
+        <translation>Datei öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="411"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="878"/>
+        <source>Files</source>
+        <translation>Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="476"/>
+        <source>pixels</source>
+        <translation>Pixel</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="477"/>
+        <source>%</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="508"/>
+        <source>Cannot load image for preview.</source>
+        <translation type="unfinished">Bild kann nicht für Vorschau geladen werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="600"/>
+        <source>Select Target Directory</source>
+        <translation type="unfinished">Zielverzeichnis auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="862"/>
+        <source>done</source>
+        <translation>Fertig</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="921"/>
+        <source>Threads: %1/%2</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>BatchWorker</name>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1040"/>
+        <source>input</source>
+        <translation type="unfinished">Eingabe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1045"/>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1053"/>
+        <source>already exists</source>
+        <translation type="unfinished">existiert bereits</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1062"/>
+        <source>cannot read</source>
+        <translation type="unfinished">kann nicht gelesen werden</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1071"/>
+        <source>over-crop</source>
+        <translation type="unfinished">Beschneidungsgrenzen überschritten</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1187"/>
+        <source>resized to zero</source>
+        <translation type="unfinished">Größe auf 0 geändert</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/batchdialog.cpp" line="1200"/>
+        <source>cannot write</source>
+        <translation type="unfinished">kann nicht schreiben</translation>
+    </message>
+</context>
+<context>
+    <name>ColorAdjDialog</name>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="17"/>
+        <source>Color Adjust</source>
+        <translation>Farbanpassung</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="101"/>
+        <source>Saturation:</source>
+        <translation>Sättigung:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="108"/>
+        <source>Green:</source>
+        <translation>Grün:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="160"/>
+        <source>Brightness:</source>
+        <translation>Helligkeit:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="180"/>
+        <source>Gamma:</source>
+        <translation>Gamma-Korrektur:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="228"/>
+        <source>Exposure:</source>
+        <translation>Belichtung:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="248"/>
+        <source>Contrast:</source>
+        <translation>Kontrast:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="268"/>
+        <source>Red:</source>
+        <translation>Rot:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="330"/>
+        <source>Blue:</source>
+        <translation>Blau:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="337"/>
+        <source>Hue:</source>
+        <translation>Farbton:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/coloradjdialog.ui" line="363"/>
+        <source>Save parameters</source>
+        <translation>Werte speichern</translation>
+    </message>
+</context>
+<context>
+    <name>CustomSelectionDialog</name>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="17"/>
+        <source>Custom selection</source>
+        <translation>Benutzerdefinierte Auswahl</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="27"/>
+        <source>Aspect ratio:</source>
+        <translation>Seitenverhältnis:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="51"/>
+        <source>Select aspect ratio</source>
+        <translation>Seitenverhältnis auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="72"/>
+        <source>,</source>
+        <translation>,</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="79"/>
+        <source>Size:</source>
+        <translation>Größe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="120"/>
+        <source>Position:</source>
+        <translation>Position:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="134"/>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.ui" line="154"/>
+        <source>:</source>
+        <translation>:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.cpp" line="40"/>
+        <source>Current image</source>
+        <translation>Aktuelles Bild</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.cpp" line="59"/>
+        <source>Ignore</source>
+        <translation>Ignorieren</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/customselectiondialog.cpp" line="173"/>
+        <source>The selection is too big!</source>
+        <translation>Die Auswahhl ist zu groß!</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleBlur</name>
+    <message>
+        <location filename="../src/effects/moduleBlur.cpp" line="37"/>
+        <source>Radius</source>
+        <translation>Radius</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleBlur.h" line="36"/>
+        <source>Blur</source>
+        <translation>Blur (Verwischen)</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleCharcoal</name>
+    <message>
+        <location filename="../src/effects/moduleCharcoal.h" line="36"/>
+        <source>Charcoal</source>
+        <translation type="unfinished">Kohlezeichnung</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleColorAdjust</name>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="38"/>
+        <source>Brightness</source>
+        <translation>Helligkeit</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="47"/>
+        <source>Contrast</source>
+        <translation>Kontrast</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="56"/>
+        <source>Gamma</source>
+        <translation>Gamma-Korrektur</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="65"/>
+        <source>Saturation</source>
+        <translation>Sättigung</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="74"/>
+        <source>Hue</source>
+        <translation>Farbton</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="83"/>
+        <source>Red</source>
+        <translation>Rot</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="92"/>
+        <source>Green</source>
+        <translation>Grün</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.cpp" line="101"/>
+        <source>Blue</source>
+        <translation>Blau</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorAdjust.h" line="36"/>
+        <source>Color Adjust</source>
+        <translation>Farbanpassung</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleColorQuantization</name>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="37"/>
+        <source>Method</source>
+        <translation>Methode</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="43"/>
+        <source>Grayscale</source>
+        <translation>Graustufen</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="44"/>
+        <source>Web-safe colors</source>
+        <translation type="unfinished">Farben für Internetseitenverwendung</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="45"/>
+        <source>Sorted colors</source>
+        <translation type="unfinished">Farbsortierung</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="49"/>
+        <source>Colors</source>
+        <translation>Farben</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="58"/>
+        <source>Dithering</source>
+        <translation>Dithering / Fehlerdiffusion</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.cpp" line="64"/>
+        <source>None</source>
+        <translation type="unfinished">Keine</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorQuantization.h" line="40"/>
+        <source>Color Quantization</source>
+        <translation type="unfinished">Farb-Quantisierung</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleColorTemperature</name>
+    <message>
+        <location filename="../src/effects/moduleColorTemperature.cpp" line="38"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleColorTemperature.h" line="36"/>
+        <source>Color Temperature</source>
+        <translation>Farbtemperatur</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleDespeckle</name>
+    <message>
+        <location filename="../src/effects/moduleDespeckle.h" line="36"/>
+        <source>Despeckle</source>
+        <translation>Flecken entfenen</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleHistEqual</name>
+    <message>
+        <location filename="../src/effects/moduleHistEqual.h" line="36"/>
+        <source>Histogram equalization</source>
+        <translation type="unfinished">Histogrammausgleich</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleMedian</name>
+    <message>
+        <location filename="../src/effects/moduleMedian.cpp" line="48"/>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleMedian.h" line="36"/>
+        <source>Median</source>
+        <translation>Median</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleNormalize</name>
+    <message>
+        <location filename="../src/effects/moduleNormalize.h" line="36"/>
+        <source>Normalize</source>
+        <translation type="unfinished">Normalisieren</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleReduceNoise</name>
+    <message>
+        <location filename="../src/effects/moduleReduceNoise.h" line="36"/>
+        <source>Reduce noise</source>
+        <translation type="unfinished">Rauschverminderung</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleSepia</name>
+    <message>
+        <location filename="../src/effects/moduleSepia.h" line="36"/>
+        <source>Sepia</source>
+        <translation type="unfinished">Sepia</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleSharpen</name>
+    <message>
+        <location filename="../src/effects/moduleSharpen.cpp" line="38"/>
+        <source>Strength</source>
+        <translation type="unfinished">Stärke</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSharpen.h" line="36"/>
+        <source>Sharpen</source>
+        <translation type="unfinished">Schärfen</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleSobel</name>
+    <message>
+        <location filename="../src/effects/moduleSobel.h" line="36"/>
+        <source>Sobel edge detector</source>
+        <translation type="unfinished">Sobel-Kantenerkennungsfilters</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleSpread</name>
+    <message>
+        <location filename="../src/effects/moduleSpread.cpp" line="47"/>
+        <source>Spread</source>
+        <translation type="unfinished">Verteilung</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSpread.h" line="36"/>
+        <source>Spread pixels</source>
+        <translation type="unfinished">Pixel verteilen</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleSwapChannels</name>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="36"/>
+        <source>RGB to</source>
+        <translation type="unfinished">RGB umwandeln in</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="42"/>
+        <source>RGB</source>
+        <translation type="unfinished">RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="43"/>
+        <source>RBG</source>
+        <translation type="unfinished">RBG</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="44"/>
+        <source>GRB</source>
+        <translation type="unfinished">GRB</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="45"/>
+        <source>GBR</source>
+        <translation type="unfinished">GBR</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="46"/>
+        <source>BRG</source>
+        <translation type="unfinished">BRG</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.cpp" line="47"/>
+        <source>BGR</source>
+        <translation type="unfinished">BGR</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleSwapChannels.h" line="36"/>
+        <source>Swap channels</source>
+        <translation type="unfinished">Kanäle tauschen</translation>
+    </message>
+</context>
+<context>
+    <name>EffectModuleUnsharp</name>
+    <message>
+        <location filename="../src/effects/moduleUnsharp.cpp" line="37"/>
+        <source>Radius</source>
+        <translation>Radius</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleUnsharp.cpp" line="46"/>
+        <source>Amount</source>
+        <translation type="unfinished">Stärke</translation>
+    </message>
+    <message>
+        <location filename="../src/effects/moduleUnsharp.h" line="36"/>
+        <source>Unsharp</source>
+        <translation type="unfinished">Entschärfen</translation>
+    </message>
+</context>
+<context>
+    <name>EffectsDialog</name>
+    <message>
+        <location filename="../src/dialogs/effectsdialog.ui" line="17"/>
+        <source>Effects</source>
+        <translation>Effekte</translation>
+    </message>
+</context>
+<context>
+    <name>ExtToolConfigDialog</name>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="23"/>
+        <source>External tools config</source>
+        <translation type="unfinished">Externe Werkzeuge</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="44"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="73"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="124"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="162"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="191"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="210"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="272"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="291"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="333"/>
+        <source>BMP</source>
+        <translation type="unfinished">BMP</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="49"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="78"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="129"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="167"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="196"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="215"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="277"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="296"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="338"/>
+        <source>JPG</source>
+        <translation type="unfinished">JPG</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="54"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="83"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="134"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="172"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="201"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="220"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="282"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="301"/>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="343"/>
+        <source>PNG</source>
+        <translation type="unfinished">PNG</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="103"/>
+        <source>File type</source>
+        <translation type="unfinished">Dateityp</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="154"/>
+        <source>Shell</source>
+        <translation type="unfinished">Shell</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.ui" line="360"/>
+        <source>Full path of the script </source>
+        <translation type="unfinished">Vollständiger Pfad des Skripts</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.cpp" line="61"/>
+        <source>Select file</source>
+        <translation>Datei auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.cpp" line="104"/>
+        <source>External tools are scripts, that takes two argument:
+1) input file path
+2) output file path
+Both paths are provided to these scripts.
+Shell can be for example /bin/sh or /usr/bin/python.
+The input and output file type shall be the same.
+The output file shall be created via the script.
+Both files are deleted automatically.
+
+Example sh script (copy the image unaltered):
+</source>
+        <translation type="unfinished">Externe Werkzeuge sind Skripte, die 2 Argumente annehmen:
+1) Verzeichnis für Eingabedatei
+2) Verzeichnis für Ausgabedatei
+Beide Verzeichnisse werden diesen Skripten bereitgestellt.
+Shell kann z.B. /bin/sh or /usr/bin/python sein.
+Eingabe- und Ausgabedateiformat sollen gleich sein.
+Die Ausgabedatei soll durch das Skript erstellt werden.
+Beide Dateien werden automatisch gelöscht.
+
+Beispiel-sh-Skript (das Bild unverändert kopieren):
+</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/exttoolconfigdialog.cpp" line="117"/>
+        <source>Help</source>
+        <translation>Hilfe</translation>
+    </message>
+</context>
+<context>
+    <name>IOmoduleQt</name>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="75"/>
+        <source>Compression</source>
+        <translation>Komprimierung</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="80"/>
+        <source>no compression</source>
+        <translation>Keine Komprimierung</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="81"/>
+        <source>LZW compression</source>
+        <translation>LZW-Komprimierung</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="86"/>
+        <source>Compression ratio</source>
+        <translation>Komprimierungsverhältnis</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="100"/>
+        <source>Compression level</source>
+        <translation>Komprimierungsstufe</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="109"/>
+        <source>Quality</source>
+        <translation>Qualität</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="121"/>
+        <source>Optimized write</source>
+        <translation type="unfinished">Optimisiertes Schreiben</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleQt.cpp" line="130"/>
+        <source>Progressive scan</source>
+        <translation type="unfinished">Progressive Abtastung</translation>
+    </message>
+</context>
+<context>
+    <name>IOmoduleVips</name>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="166"/>
+        <source>Quality</source>
+        <translation>Qualität</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="177"/>
+        <source>Lossless</source>
+        <translation>Verlustfrei</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="186"/>
+        <source>Compression</source>
+        <translation>Komprimierung</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="191"/>
+        <source>Auto</source>
+        <translation>Automatisch</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="192"/>
+        <source>AOM</source>
+        <translation type="unfinished">AOM</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="193"/>
+        <source>RAV1E</source>
+        <translation type="unfinished">RAV1E</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="194"/>
+        <source>SVT</source>
+        <translation type="unfinished">SVT</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="195"/>
+        <source>x265</source>
+        <translation type="unfinished">x265</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="202"/>
+        <source>Dithering</source>
+        <translation type="unfinished">Dithering / Fehlerdiffusion</translation>
+    </message>
+    <message>
+        <location filename="../src/io/moduleVips.cpp" line="210"/>
+        <source>Quantisation effort</source>
+        <translation type="unfinished">Quantisierungsaufwand</translation>
+    </message>
+</context>
+<context>
+    <name>InfoDialog</name>
+    <message>
+        <location filename="../src/dialogs/infodialog.ui" line="17"/>
+        <source>Info</source>
+        <translation type="unfinished">Information</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/infodialog.cpp" line="36"/>
+        <source>This functionality requires &apos;exiftool&apos; to be installed</source>
+        <translation type="unfinished">Für diese Funktion muß &apos;exiftool&apos;installiert sein</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/infodialog.cpp" line="46"/>
+        <source>Tag</source>
+        <translation type="unfinished">Tag / Eintrag</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/infodialog.cpp" line="47"/>
+        <source>Value</source>
+        <translation type="unfinished">Wert</translation>
+    </message>
+</context>
+<context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="17"/>
+        <source>License</source>
+        <translation>Lizenz</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="35"/>
+        <source>ClassicImageViewer</source>
+        <translation>ClassicImageViewer </translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="44"/>
+        <source>                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. &lt;https://fsf.org/&gt;
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers&apos; and authors&apos; protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users&apos; and
+authors&apos; sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users&apos; freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  &quot;This License&quot; refers to version 3 of the GNU General Public License.
+
+  &quot;Copyright&quot; also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  &quot;The Program&quot; refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as &quot;you&quot;.  &quot;Licensees&quot; and
+&quot;recipients&quot; may be individuals or organizations.
+
+  To &quot;modify&quot; a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a &quot;modified version&quot; of the
+earlier work or a work &quot;based on&quot; the earlier work.
+
+  A &quot;covered work&quot; means either the unmodified Program or a work based
+on the Program.
+
+  To &quot;propagate&quot; a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To &quot;convey&quot; a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays &quot;Appropriate Legal Notices&quot;
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The &quot;source code&quot; for a work means the preferred form of the work
+for making modifications to it.  &quot;Object code&quot; means any non-source
+form of a work.
+
+  A &quot;Standard Interface&quot; means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The &quot;System Libraries&quot; of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+&quot;Major Component&quot;, in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The &quot;Corresponding Source&quot; for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work&apos;s
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users&apos; Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work&apos;s
+users, your or third parties&apos; legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program&apos;s source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    &quot;keep intact all notices&quot;.
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+&quot;aggregate&quot; if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation&apos;s users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A &quot;User Product&quot; is either (1) a &quot;consumer product&quot;, which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, &quot;normally used&quot; refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  &quot;Installation Information&quot; for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  &quot;Additional permissions&quot; are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered &quot;further
+restrictions&quot; within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An &quot;entity transaction&quot; is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party&apos;s predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A &quot;contributor&quot; is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor&apos;s &quot;contributor version&quot;.
+
+  A contributor&apos;s &quot;essential patent claims&quot; are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, &quot;control&quot; includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor&apos;s essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a &quot;patent license&quot; is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To &quot;grant&quot; such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  &quot;Knowingly relying&quot; means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient&apos;s use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is &quot;discriminatory&quot; if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others&apos; Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License &quot;or any later version&quot; applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy&apos;s
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM &quot;AS IS&quot; WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the &quot;copyright&quot; line and a pointer to where the full notice is found.
+
+    &lt;one line to give the program&apos;s name and a brief idea of what it does.&gt;
+    Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    &lt;program&gt;  Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w&apos;.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c&apos; for details.
+
+The hypothetical commands `show w&apos; and `show c&apos; should show the appropriate
+parts of the General Public License.  Of course, your program&apos;s commands
+might be different; for a GUI interface, you would use an &quot;about box&quot;.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a &quot;copyright disclaimer&quot; for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+&lt;https://www.gnu.org/licenses/&gt;.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+&lt;https://www.gnu.org/licenses/why-not-lgpl.html&gt;.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="726"/>
+        <source>GNOME icons</source>
+        <translation type="unfinished">GNOME-Symbole</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="735"/>
+        <source>GNOME icon theme is distributed under the terms of either GNU LGPL v.3 or Creative Commons BY-SA 3.0 license.
+
+This work is licenced under the Creative Commons Attribution-Share Alike 3.0
+United States License. To view a copy of this licence, visit
+http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative
+Commons, 171 Second Street, Suite 300, San Francisco, California 94105, USA.
+
+When attributing the artwork, using &quot;GNOME Project&quot; is enough. 
+Please link to http://www.gnome.org where available.
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, &quot;this License&quot; refers to version 3 of the GNU Lesser
+General Public License, and the &quot;GNU GPL&quot; refers to version 3 of the GNU
+General Public License.
+
+  &quot;The Library&quot; refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An &quot;Application&quot; is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A &quot;Combined Work&quot; is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the &quot;Linked
+Version&quot;.
+
+  The &quot;Minimal Corresponding Source&quot; for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The &quot;Corresponding Application Code&quot; for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user&apos;s computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License &quot;or any later version&quot;
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy&apos;s public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="919"/>
+        <source>QOI</source>
+        <translation type="unfinished">QOI</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/licensedialog.ui" line="928"/>
+        <source>MIT License
+
+Copyright (c) 2022 Dominic Szablewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/mainwindow.ui" line="20"/>
+        <source>ClassicImageViewer</source>
+        <translation>ClassicImageViewer</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="63"/>
+        <source>&amp;File</source>
+        <translation>&amp;Datei</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="68"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="73"/>
+        <source>&amp;Image</source>
+        <translation>B&amp;ild</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="78"/>
+        <source>&amp;Options</source>
+        <translation>&amp;Optionen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="83"/>
+        <source>&amp;View</source>
+        <translation>&amp;Ansicht</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="88"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Hilfe</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="306"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="307"/>
+        <source>&amp;Reload</source>
+        <translation type="unfinished">&amp;Neu laden</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="308"/>
+        <source>Reopen in new app</source>
+        <translation type="unfinished">In neuem Fenster erneut öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="309"/>
+        <source>Open in &amp;external editor</source>
+        <translation type="unfinished">In &amp;externem Editor öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="310"/>
+        <source>Recent &amp;files</source>
+        <translation type="unfinished">Zuletzt geöffnete &amp;Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="313"/>
+        <source>&amp;Thumbnails</source>
+        <translation type="unfinished">&amp;Vorschaubilder</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="314"/>
+        <source>Slidesho&amp;w</source>
+        <translation type="unfinished">Dia&amp;schau</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="315"/>
+        <source>&amp;Batch conversion</source>
+        <translation type="unfinished">&amp;Batch(Stapel)-Konvertierung / Umbenennung</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="317"/>
+        <source>Re&amp;name file</source>
+        <translation type="unfinished">Datei &amp;umbennen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
+        <source>Select target directory</source>
+        <translation>Zielverzeichnis auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
+        <source>&amp;Move file</source>
+        <translation type="unfinished">Datei &amp;verschieben</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="320"/>
+        <source>&amp;Copy file</source>
+        <translation type="unfinished">Datei &amp;kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="321"/>
+        <source>&amp;Delete file</source>
+        <translation type="unfinished">Datei &amp;löschen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="323"/>
+        <source>Sa&amp;ve</source>
+        <translation type="unfinished">S&amp;peichern</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="324"/>
+        <source>&amp;Save as</source>
+        <translation type="unfinished">&amp;Speichern unter</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="325"/>
+        <source>Save selection as</source>
+        <translation type="unfinished">Auswahl speichern als</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="326"/>
+        <source>&amp;Print</source>
+        <translation type="unfinished">&amp;Drucken</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">&amp;Beenden</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="331"/>
+        <source>&amp;Undo</source>
+        <translation type="unfinished">R&amp;ückgängig</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="332"/>
+        <source>R&amp;edo</source>
+        <translation type="unfinished">Wi&amp;ederholen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="334"/>
+        <source>Cust&amp;om selection</source>
+        <translation type="unfinished">&amp;Benutzerdefinierte Auswahl</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="335"/>
+        <source>Cut &amp;selection</source>
+        <translation type="unfinished">Au&amp;swahl ausschneiden</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="336"/>
+        <source>C&amp;rop selection</source>
+        <translation type="unfinished">Auswahl &amp;freistellen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="338"/>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="339"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished">&amp;Einfügen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="340"/>
+        <source>Paste to side</source>
+        <translation type="unfinished">Seitlich einfügen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="341"/>
+        <source>Unloa&amp;d</source>
+        <translation type="unfinished">Entla&amp;den</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
+        <source>C&amp;lear clipboard</source>
+        <translation type="unfinished">&amp;Zwischenablage leeren</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="346"/>
+        <source>&amp;Information</source>
+        <translation>&amp;Information</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="348"/>
+        <source>Rotate &amp;left</source>
+        <translation>Nach &amp;links drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="349"/>
+        <source>Rotate &amp;right</source>
+        <translation>Nach &amp;rechts drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="350"/>
+        <source>C&amp;ustom rotation</source>
+        <translation>Ben&amp;utzerdefiniertes Drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="351"/>
+        <source>&amp;Vertical flip</source>
+        <translation>&amp;Vertikal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="352"/>
+        <source>&amp;Horizontal flip</source>
+        <translation>&amp;Horizontal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="354"/>
+        <source>Re&amp;size</source>
+        <translation type="unfinished">Grö&amp;ße ändern</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="355"/>
+        <source>Add &amp;border</source>
+        <translation type="unfinished">Ran&amp;d hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="356"/>
+        <source>&amp;Pad to size</source>
+        <translation type="unfinished">&amp;Auffüllen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="358"/>
+        <source>I&amp;ncrease color depth</source>
+        <translation type="unfinished">Farbtiefe erhöhe&amp;n</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="359"/>
+        <source>&amp;Decrease color depth</source>
+        <translation type="unfinished">Farbtiefe re&amp;duzieren</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="361"/>
+        <source>&amp;Grayscale</source>
+        <translation>&amp;Graustufen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="363"/>
+        <source>Adjust &amp;colors</source>
+        <translation type="unfinished">Farben &amp;anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="365"/>
+        <source>Auto c&amp;olor adjust</source>
+        <translation>Aut&amp;omatische Farbanpassung</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="369"/>
+        <source>E&amp;xternal tools</source>
+        <translation>E&amp;xterne Werkzeuge</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="370"/>
+        <source>Configure</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="372"/>
+        <source>External tool 1</source>
+        <translation type="unfinished">Externes Werkzeug 1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="373"/>
+        <source>External tool 2</source>
+        <translation type="unfinished">Externes Werkzeug 2</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
+        <source>External tool 3</source>
+        <translation type="unfinished">Externes Werkzeug 3</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="375"/>
+        <source>External tool 4</source>
+        <translation type="unfinished">Externes Werkzeug 4</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="376"/>
+        <source>External tool 5</source>
+        <translation type="unfinished">Externes Werkzeug 5</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="377"/>
+        <source>External tool 6</source>
+        <translation type="unfinished">Externes Werkzeug 6</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="378"/>
+        <source>External tool 7</source>
+        <translation type="unfinished">Externes Werkzeug 7</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="379"/>
+        <source>External tool 8</source>
+        <translation type="unfinished">Externes Werkzeug 8</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="380"/>
+        <source>External tool 9</source>
+        <translation type="unfinished">Externes Werkzeug 9</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="383"/>
+        <source>&amp;Properties</source>
+        <translation type="unfinished">&amp;Eigenschaften</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="387"/>
+        <source>Toggle &amp;status bar</source>
+        <translation>&amp;Statusleiste ein-/ausschalten</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="388"/>
+        <source>Toggle &amp;toolbar</source>
+        <translation>Werkzeugleis&amp;te ein-/ausschalten</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="389"/>
+        <source>Toggle &amp;menu bar</source>
+        <translation>&amp;Menüleiste ein-/ausschalten</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="391"/>
+        <source>&amp;Display mode</source>
+        <translation type="unfinished">Anzeige-Optionen (Fenstermo&amp;dus)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="392"/>
+        <source>Fit window to images</source>
+        <translation type="unfinished">Fenstergröße an Bilder anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="393"/>
+        <source>Fit all images to window</source>
+        <translation type="unfinished">Alle Bilder an Fenstergröße anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="394"/>
+        <source>Fit large images to window</source>
+        <translation type="unfinished">Große Bilder an Fenstergröße anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="395"/>
+        <source>Fit all images to desktop</source>
+        <translation type="unfinished">Alle Bilder an Schreibtisch anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="396"/>
+        <source>Fit large images to desktop</source>
+        <translation type="unfinished">Große Bilder an Schreibtisch anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="397"/>
+        <source>Do not fit</source>
+        <translation type="unfinished">Nicht anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="404"/>
+        <source>Fi&amp;rst file in directory</source>
+        <translation type="unfinished">E&amp;rste Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="407"/>
+        <source>Zoom &amp;in</source>
+        <translation type="unfinished">Vergrößer&amp;n</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="409"/>
+        <source>Zoom 1:1</source>
+        <translation type="unfinished">Originalgröße</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="410"/>
+        <source>&amp;Zoom levels</source>
+        <translation type="unfinished">&amp;Vergrößerungsstufen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="412"/>
+        <source>10%</source>
+        <translation>10%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="413"/>
+        <source>15%</source>
+        <translation>15%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="414"/>
+        <source>20%</source>
+        <translation>20%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="415"/>
+        <source>25%</source>
+        <translation>25%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="416"/>
+        <source>33%</source>
+        <translation>33%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="417"/>
+        <source>50%</source>
+        <translation>50%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="418"/>
+        <source>66%</source>
+        <translation>66%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="419"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="420"/>
+        <source>125%</source>
+        <translation>125%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="421"/>
+        <source>150%</source>
+        <translation>150%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="422"/>
+        <source>175%</source>
+        <translation>175%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="423"/>
+        <source>200%</source>
+        <translation>200%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="424"/>
+        <source>300%</source>
+        <translation>300%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="425"/>
+        <source>400%</source>
+        <translation>400%</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="430"/>
+        <source>Increase transparency</source>
+        <translation>Transparenz erhöhen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="432"/>
+        <source>Decrease transparency</source>
+        <translation>Transparenz reduzieren</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="434"/>
+        <source>First file in directory</source>
+        <translation type="unfinished">Erste Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="435"/>
+        <source>Last file in directory</source>
+        <translation type="unfinished">Letzte Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="436"/>
+        <location filename="../src/mainwindow.cpp" line="438"/>
+        <location filename="../src/mainwindow.cpp" line="440"/>
+        <source>Previous file in directory</source>
+        <translation type="unfinished">Vorherige Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="437"/>
+        <location filename="../src/mainwindow.cpp" line="439"/>
+        <location filename="../src/mainwindow.cpp" line="441"/>
+        <source>Next file in directory</source>
+        <translation type="unfinished">Nächste Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="442"/>
+        <source>Toggle selection all</source>
+        <translation type="unfinished">&quot;Alles auswählen&quot; ein-/ausschalten</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="443"/>
+        <source>Adjust left side of the selection</source>
+        <translation type="unfinished">Auswahl links anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="444"/>
+        <source>Adjust top side of the selection</source>
+        <translation type="unfinished">Auswahl oben anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="445"/>
+        <source>Adjust right side of the selection</source>
+        <translation type="unfinished">Auswahl rechts anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="446"/>
+        <source>Adjust bottom side of the selection</source>
+        <translation type="unfinished">Auswahl unten anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="447"/>
+        <source>Move selection</source>
+        <translation type="unfinished">Auswahl verschieben</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1141"/>
+        <source>Color Quantization</source>
+        <translation type="unfinished">Farbreduktion</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1237"/>
+        <source>External tool %1 is not configured.</source>
+        <translation type="unfinished">Externes Werkzeug %1ist nicht konfiguriert.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1268"/>
+        <source>Failed to save the script input file.</source>
+        <translation type="unfinished">Eingangsdatei des Skriptes konnte nicht gespeichert werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1279"/>
+        <source>External tool %1 failed to start.</source>
+        <translation type="unfinished">Externes Werkzeug %1 konnte nicht gestartet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1284"/>
+        <source>External tool %1</source>
+        <translation type="unfinished">Externes Werkzeug %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1285"/>
+        <source>The execution of the script is in progress...</source>
+        <translation type="unfinished">Skript wird ausgeführt...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1307"/>
+        <source>Failed to load the script output file.</source>
+        <translation type="unfinished">Ausgabedatei des Skriptes konnte nicht geladen werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1980"/>
+        <source>Indexing the current directory...</source>
+        <translation type="unfinished">Aktuelles Verzeichnis indexieren...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="2600"/>
+        <source>Save...</source>
+        <translation type="unfinished">Speichern...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="362"/>
+        <source>Nega&amp;tive</source>
+        <translation type="unfinished">Nega&amp;tive</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="366"/>
+        <source>Sh&amp;arpen</source>
+        <translation type="unfinished">Sch&amp;ärfen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="367"/>
+        <source>&amp;Effects</source>
+        <translation type="unfinished">&amp;Effekte</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="384"/>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimieren</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="400"/>
+        <source>&amp;Full screen</source>
+        <translation type="unfinished">&amp;Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="402"/>
+        <source>&amp;Next file in directory</source>
+        <translation type="unfinished">&amp;Nächste Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="403"/>
+        <source>&amp;Previous file in directory</source>
+        <translation type="unfinished">Vo&amp;rherige Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="405"/>
+        <source>&amp;Last file in directory</source>
+        <translation type="unfinished">&amp;Letzte Datei im Verzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="408"/>
+        <source>Zoom &amp;out</source>
+        <translation type="unfinished">V&amp;erkleinern</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="428"/>
+        <source>&amp;License</source>
+        <translation type="unfinished">&amp;Lizenz</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="429"/>
+        <source>&amp;Shortcuts</source>
+        <translation type="unfinished">Ta&amp;stenkürzel</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="430"/>
+        <source>&amp;About</source>
+        <translation type="unfinished">&amp;Über</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="610"/>
+        <location filename="../src/mainwindow.cpp" line="625"/>
+        <location filename="../src/mainwindow.cpp" line="647"/>
+        <location filename="../src/mainwindow.cpp" line="651"/>
+        <location filename="../src/mainwindow.cpp" line="686"/>
+        <location filename="../src/mainwindow.cpp" line="690"/>
+        <location filename="../src/mainwindow.cpp" line="736"/>
+        <location filename="../src/mainwindow.cpp" line="740"/>
+        <location filename="../src/mainwindow.cpp" line="780"/>
+        <location filename="../src/mainwindow.cpp" line="807"/>
+        <location filename="../src/mainwindow.cpp" line="838"/>
+        <location filename="../src/mainwindow.cpp" line="913"/>
+        <location filename="../src/mainwindow.cpp" line="947"/>
+        <location filename="../src/mainwindow.cpp" line="1237"/>
+        <location filename="../src/mainwindow.cpp" line="1268"/>
+        <location filename="../src/mainwindow.cpp" line="1279"/>
+        <location filename="../src/mainwindow.cpp" line="1307"/>
+        <location filename="../src/mainwindow.cpp" line="2031"/>
+        <source>Error</source>
+        <translation type="unfinished">Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="610"/>
+        <source>Cannot rename to empty filename.</source>
+        <translation type="unfinished">Kann nicht in leeren Dateinamen umbennen.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="625"/>
+        <source>Failed to rename the file.
+Maybe the provided file name already exists.</source>
+        <translation type="unfinished">Umbennen der Datei fehlgeschlagen.
+Eventuell existiert bereits eine Datei mit dem angegebenen Dateinamen.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="647"/>
+        <location filename="../src/mainwindow.cpp" line="686"/>
+        <source>Target directory not set.</source>
+        <translation type="unfinished">Kein Zielverteichnis angebeben.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="651"/>
+        <location filename="../src/mainwindow.cpp" line="690"/>
+        <source>Target directory cannot be the current one.</source>
+        <translation type="unfinished">Zielverzeichnis darf nicht das aktuell verwendete sein.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="736"/>
+        <source>Failed to move %1 to trash.</source>
+        <translation type="unfinished">Konnte %1 nicht in den Papierkorb verschieben.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="740"/>
+        <source>Failed to move %1 to trash.
+Currently only &apos;gio&apos; and &apos;kioclient5&apos; based operation supported.</source>
+        <translation type="unfinished">Konnte %1 nicht in den Papierkorb verschieben.
+Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operationen unterstützt.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="780"/>
+        <location filename="../src/mainwindow.cpp" line="807"/>
+        <source>Save to %1 failed.</source>
+        <translation type="unfinished">Speichern nach %1 fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="838"/>
+        <source>Printer initialization failed.</source>
+        <translation type="unfinished">Druckereinrichtung fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="913"/>
+        <location filename="../src/mainwindow.cpp" line="947"/>
+        <source>QClipboard error.</source>
+        <translation type="unfinished">Zwischenablagefehler (Qt).</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="921"/>
+        <source>Clipboard %1</source>
+        <translation type="unfinished">Zwischenablage %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1626"/>
+        <location filename="../src/mainwindow.cpp" line="1627"/>
+        <source>Trying to hack the clipboard...</source>
+        <translation type="unfinished">Versuche Zwischenablage zu hacken...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1672"/>
+        <location filename="../src/mainwindow.cpp" line="1885"/>
+        <source>No file loaded</source>
+        <translation type="unfinished">Keine Datei geladen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1696"/>
+        <location filename="../src/mainwindow.cpp" line="1886"/>
+        <source>No selection</source>
+        <translation type="unfinished">Keine Auswahl</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1700"/>
+        <source>Selection: %1x%2 at (%3,%4)</source>
+        <translation type="unfinished">Auswahl: %1x%2 at (%3,%4)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="1724"/>
+        <source>Pixel: %1 at (%2,%3)</source>
+        <translation type="unfinished">Pixel: %1 at (%2,%3)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="2031"/>
+        <source>Can not open %1</source>
+        <translation type="unfinished">%1 kann nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="2518"/>
+        <source>&amp;Clear recent files</source>
+        <translation type="unfinished">Liste der zuletzt &amp;geöffneten Dateien löschen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="2543"/>
+        <source>All supported images</source>
+        <translation type="unfinished">Alle unterstützten Bilder</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="2556"/>
+        <source>All files</source>
+        <translation type="unfinished">Alle Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="2559"/>
+        <source>Open File</source>
+        <translation>Datei öffnen</translation>
+    </message>
+</context>
+<context>
+    <name>PadToSizeDialog</name>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="17"/>
+        <source>Pad to size</source>
+        <translation type="unfinished">Farb-Rahmen hinzufügen / Leinwandgröße ändern</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="64"/>
+        <source>New size:</source>
+        <translation type="unfinished">Neue Größe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="78"/>
+        <source>x</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="92"/>
+        <source>Aspect ratio:</source>
+        <translation type="unfinished">Seitenverhältnis:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="119"/>
+        <source>:</source>
+        <translation>:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="143"/>
+        <source>Color</source>
+        <translation>Farbe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/padtosizedialog.ui" line="163"/>
+        <source>Direction:</source>
+        <translation type="unfinished">Ausrichtung:</translation>
+    </message>
+</context>
+<context>
+    <name>PasteToSideDialog</name>
+    <message>
+        <location filename="../src/dialogs/pastetosidedialog.ui" line="23"/>
+        <source>Paste to side</source>
+        <translation>Seitlich einfügen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/pastetosidedialog.ui" line="63"/>
+        <source>Image</source>
+        <translation>Bild</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesDialog</name>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="23"/>
+        <source>Preferences</source>
+        <translation type="unfinished">Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="62"/>
+        <source>General</source>
+        <translation type="unfinished">Allgemein</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="104"/>
+        <source>Name</source>
+        <translation type="unfinished">Nach Name</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="109"/>
+        <source>Name (reversed)</source>
+        <translation type="unfinished">Nach Name (umgekehrt)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="114"/>
+        <source>Time</source>
+        <translation type="unfinished">Nach Zeit</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="119"/>
+        <source>Time (reversed)</source>
+        <translation type="unfinished">Nach Zeit (umgekehrt)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="317"/>
+        <source>System</source>
+        <translation type="unfinished">System</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="296"/>
+        <source>Start maximized</source>
+        <translation type="unfinished">Maximiert starten</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="315"/>
+        <source>Display</source>
+        <translation type="unfinished">Anzeige</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="182"/>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="428"/>
+        <source>Display mode:</source>
+        <translation type="unfinished">Anzeige-Optionen (Fenstermodus):</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="263"/>
+        <source>Fit window to images</source>
+        <translation type="unfinished">Fenstergröße an Bilder anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="268"/>
+        <source>Fit all images to window</source>
+        <translation type="unfinished">Alle Bilder an Fenstergröße anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="273"/>
+        <source>Fit large images to window</source>
+        <translation type="unfinished">Große Bilder an Fenstergröße anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="248"/>
+        <source>Zoom delta:</source>
+        <translation type="unfinished">Zoom-Faktor:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="331"/>
+        <source>Locale:</source>
+        <translation type="unfinished">Spracheinstellung:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="241"/>
+        <source>Clear Clipboard on exit</source>
+        <translation>Zwischenablage beim Beenden leeren</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="226"/>
+        <source>Clear recent files on exit</source>
+        <translation type="unfinished">Liste der zuletzt geöffneten Dateien beim Beenden löschen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="82"/>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="168"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="199"/>
+        <source>(if disabled, the exit could take a long time)</source>
+        <translation type="unfinished">(wenn deaktiviert kann das nächste Schließen des Programmfensters länger dauern)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="134"/>
+        <source>File order:</source>
+        <translation type="unfinished">Dateisortierung:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="206"/>
+        <source>Loop directory</source>
+        <translation type="unfinished">Verzeichnisschleife</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="213"/>
+        <source>Display background:</source>
+        <translation type="unfinished">Anzeige-Hintergrund:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="175"/>
+        <source>Reverse mouse wheel</source>
+        <translation type="unfinished">Mausradrichtung umkehren</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="221"/>
+        <source>XOR frame</source>
+        <translation type="unfinished">XOR-Rahmen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="226"/>
+        <source>Highlight (fast)</source>
+        <translation type="unfinished">Hervorheben (schnell)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="234"/>
+        <source>(not applied on the current image)</source>
+        <translation type="unfinished">(wird nicht auf aktuelles Bild angewendet)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="75"/>
+        <source>(of white)</source>
+        <translation type="unfinished">(bezogen auf Weiß)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="89"/>
+        <source>Selection tool:</source>
+        <translation type="unfinished">Auswahlwerkzeug:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="303"/>
+        <source>Display quality:</source>
+        <translation type="unfinished">Darstellungsqualität:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="96"/>
+        <source>Fit window to images when zoomed</source>
+        <translation type="unfinished">Fenstergröße bei Vergrößerung an Bilder anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="255"/>
+        <source>Enable Toolbar shrinking</source>
+        <translation type="unfinished">Verkleinerung der Werkzeugleiste aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="155"/>
+        <source>Fast</source>
+        <translation type="unfinished">Schnell</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="160"/>
+        <source>Quality</source>
+        <translation type="unfinished">Qualität</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="127"/>
+        <source>(reduces downscaling aliasing effects)</source>
+        <translation type="unfinished">(reduziert Treppen-Effekt beim Verkleinern)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="278"/>
+        <source>Do not fit</source>
+        <translation type="unfinished">Nicht anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="283"/>
+        <source>Fit images to desktop</source>
+        <translation type="unfinished">Bilder an Schreibtisch anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="288"/>
+        <source>Fit large images to desktop</source>
+        <translation type="unfinished">Große Bilder an Schreibtisch anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="338"/>
+        <source>Start fullscreen (if image is loaded on startup)</source>
+        <translation type="unfinished">Im Vollbildmodus starten (wenn Bild beim Starten geöffnet wird)</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="354"/>
+        <source>Fullscreen</source>
+        <translation type="unfinished">Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="360"/>
+        <source>Indicator font size:</source>
+        <translation type="unfinished">Anzeige-Schriftgöße:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="367"/>
+        <source>Enable file index indicator</source>
+        <translation type="unfinished">Datei-Index-anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="375"/>
+        <source>Dark gray</source>
+        <translation type="unfinished">Dunkelgrau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="380"/>
+        <source>Gray</source>
+        <translation type="unfinished">Grau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="385"/>
+        <source>Light gray</source>
+        <translation type="unfinished">Hellgrau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="390"/>
+        <source>White</source>
+        <translation type="unfinished">Weiß</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="395"/>
+        <source>Dark red</source>
+        <translation type="unfinished">Dunkelrot</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="400"/>
+        <source>Red</source>
+        <translation type="unfinished">Rot</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="405"/>
+        <source>Dark green</source>
+        <translation type="unfinished">Dunkelgrün</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="410"/>
+        <source>Green</source>
+        <translation type="unfinished">Grün</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="415"/>
+        <source>Dark Blue</source>
+        <translation type="unfinished">Dunkelblau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="420"/>
+        <source>Blue</source>
+        <translation type="unfinished">Blau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="436"/>
+        <source>Fit all images to display</source>
+        <translation type="unfinished">Alle Bilder an Anzeige anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="441"/>
+        <source>Fit large images to display</source>
+        <translation type="unfinished">Große Bilder an Anzeige anpassen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="449"/>
+        <source>Enable file name indicator</source>
+        <translation type="unfinished">Dateiname anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="456"/>
+        <source>px</source>
+        <translation type="unfinished">px</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="476"/>
+        <source>Hide cursor</source>
+        <translation type="unfinished">Mauszeiger verbergen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="493"/>
+        <source>Indicator color:</source>
+        <translation type="unfinished">Anzeige-Farbe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="503"/>
+        <source>Indicator font:</source>
+        <translation type="unfinished">Anzeige-Schrift:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="519"/>
+        <source>Undo stack</source>
+        <translation type="unfinished">Rückgängig-Stapel</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="535"/>
+        <source>Memory limit:</source>
+        <translation type="unfinished">Speicherlimit:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="542"/>
+        <source>Minimum number of steps:</source>
+        <translation type="unfinished">Mindestanzahl an Schritten:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="572"/>
+        <source>MB</source>
+        <translation type="unfinished">MB</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="582"/>
+        <source>Thumbnails</source>
+        <translation type="unfinished">Vorschaubilder</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="615"/>
+        <source>Cache size:</source>
+        <translation type="unfinished">Cache-Größe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="622"/>
+        <source>Multithreading:</source>
+        <translation type="unfinished">Multithreading:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="630"/>
+        <source>Auto</source>
+        <translation type="unfinished">Automatisch</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="635"/>
+        <source>1</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="640"/>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="645"/>
+        <source>4</source>
+        <translation>4</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="650"/>
+        <source>8</source>
+        <translation>8</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="655"/>
+        <source>16</source>
+        <translation>16</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="660"/>
+        <source>32</source>
+        <translation>32</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="665"/>
+        <source>64</source>
+        <translation>64</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="686"/>
+        <source>Preloading</source>
+        <translation type="unfinished">Laden der Anfangsgrößen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.ui" line="608"/>
+        <source>Scroll speed:</source>
+        <translation type="unfinished">Bildlauf-Geschwindigkeit:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.cpp" line="89"/>
+        <source>Restore defaults</source>
+        <translation type="unfinished">Standardeinstellungen wiederherstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/preferencesdialog.cpp" line="89"/>
+        <source>Do you really want to clear and restore all settings to the default?
+These includes previous files, effect parameter and more...
+The application will exit.</source>
+        <translation type="unfinished">Möchten Sie die Einstellungen wirklich löschen und die Standardeinstellungen wiederherstellen?
+Dies betrifft auch &quot;zuletzt göffnete Dateien, Effekt-Einstellungen und mehr...
+Das Programm wird dann beendet.</translation>
+    </message>
+</context>
+<context>
+    <name>RenameDialog</name>
+    <message>
+        <location filename="../src/dialogs/renamedialog.ui" line="23"/>
+        <source>Rename</source>
+        <translation>Umbenennen</translation>
+    </message>
+</context>
+<context>
+    <name>ResizeDialog</name>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="17"/>
+        <source>Resize</source>
+        <translation>Größe ändern</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="55"/>
+        <source>Current resolution:</source>
+        <translation>Aktuelle Größe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="62"/>
+        <source>New resolution:</source>
+        <translation>Neue Größe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="99"/>
+        <source>New resolution :</source>
+        <translation>Neue Größe:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="106"/>
+        <source>New resolution as percentage:</source>
+        <translation>Neue Größe in Prozent:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="143"/>
+        <source>Width</source>
+        <translation>Breite</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="150"/>
+        <source>Heigth</source>
+        <translation>Höhe</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="169"/>
+        <source>Lock aspect ratio</source>
+        <translation>Seitenverhältnis sperren</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.ui" line="178"/>
+        <source>Method:</source>
+        <translation>Methode:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/resizedialog.cpp" line="29"/>
+        <location filename="../src/dialogs/resizedialog.cpp" line="167"/>
+        <source>%1 x %2</source>
+        <translation>%1 x %2</translation>
+    </message>
+</context>
+<context>
+    <name>Resizer</name>
+    <message>
+        <location filename="../src/modules/resizer.cpp" line="122"/>
+        <source>Nearest Neighbor</source>
+        <translation type="unfinished">Nächster-Nachbar-Interpolation (nearest neighbor)</translation>
+    </message>
+    <message>
+        <location filename="../src/modules/resizer.cpp" line="123"/>
+        <source>Bilinear</source>
+        <translation type="unfinished">Bilineare Interpolation (bilinear)</translation>
+    </message>
+    <message>
+        <location filename="../src/modules/resizer.cpp" line="125"/>
+        <source>Bicubic (Catmull-Rom)</source>
+        <translation type="unfinished">Bikubische Interpolation (bicubic) (Catmull-Rom)</translation>
+    </message>
+    <message>
+        <location filename="../src/modules/resizer.cpp" line="126"/>
+        <source>Bicubic (Mitchell-Netravali)</source>
+        <translation type="unfinished">Bikubische Interpolation (bicubic) (Mitchell-Netravali)</translation>
+    </message>
+    <message>
+        <location filename="../src/modules/resizer.cpp" line="127"/>
+        <location filename="../src/modules/resizer.cpp" line="130"/>
+        <source>Lanczos</source>
+        <translation type="unfinished">Lanczos Interpolation</translation>
+    </message>
+    <message>
+        <location filename="../src/modules/resizer.cpp" line="129"/>
+        <source>Bicubic</source>
+        <translation type="unfinished">Bikubische Interpolation (bicubic)</translation>
+    </message>
+</context>
+<context>
+    <name>RotateDialog</name>
+    <message>
+        <location filename="../src/dialogs/rotatedialog.ui" line="17"/>
+        <source>Rotate</source>
+        <translation type="unfinished">Drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/rotatedialog.ui" line="114"/>
+        <source>Fill color</source>
+        <translation type="unfinished">Füllfarbe</translation>
+    </message>
+</context>
+<context>
+    <name>SaveFileDialog</name>
+    <message>
+        <location filename="../src/widgets/savefiledialog.cpp" line="159"/>
+        <source>Save these settings</source>
+        <translation type="unfinished">Diese Einstellungen speichern</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="../src/dialogs/shortcutsdialog.ui" line="17"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Tastaturkürzel</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/shortcutsdialog.cpp" line="31"/>
+        <source>Shortcut</source>
+        <translation type="unfinished">Tastaturkürzel</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/shortcutsdialog.cpp" line="32"/>
+        <source>Action</source>
+        <translation type="unfinished">Aktion</translation>
+    </message>
+</context>
+<context>
+    <name>SlideshowDialog</name>
+    <message>
+        <location filename="../src/dialogs/slideshowdialog.ui" line="17"/>
+        <source>Slideshow</source>
+        <translation>Diaschau</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/slideshowdialog.ui" line="33"/>
+        <source>Interval:</source>
+        <translation>Intervall:</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/slideshowdialog.ui" line="53"/>
+        <source>sec</source>
+        <translation>Sek.</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/slideshowdialog.ui" line="77"/>
+        <source>Forward</source>
+        <translation>Vorwärts</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/slideshowdialog.ui" line="82"/>
+        <source>Backward</source>
+        <translation>Rückwärts</translation>
+    </message>
+</context>
+<context>
+    <name>TargetDirDialog</name>
+    <message>
+        <location filename="../src/dialogs/targetdirdialog.ui" line="23"/>
+        <source>Target Directory</source>
+        <translation>Zielverzeichnis</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/targetdirdialog.ui" line="31"/>
+        <source>Selec directory</source>
+        <translation>Verzeichnis auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/dialogs/targetdirdialog.cpp" line="41"/>
+        <source>Select Target Directory</source>
+        <translation>Zielverzeichnis auswählen</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailDialog</name>
+    <message>
+        <location filename="../src/dialogs/thumbnaildialog.ui" line="17"/>
+        <source>Thumbnail</source>
+        <translation type="unfinished">Vorschaubild</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Notes:

- The de.ts file was created as a copy of the en.ts file.

- There are some menu entries missing from the en.ts file and thus also missing from the de.ts file. Some missing entries have been added manually, but the line numbers in `<location filename="../src/[file name]" line="[some number]"/>` don't seem to be consistent to any specific type of entry in the respective source file, so I just chose a number a few digits different from the entries above or below I copied the code from.

- Some of the settings menu entries are still missing:
    - `Restore default`, `Cancel`, `OK`
    - The whole `External editors` and `File Formats` sections
    - `Yes`, `No` of the popup menus.

- There a at least a few translations that are up to debate / subject to change. Some I took from IrfanView, others from web articles as I didn't know if there even was a translation or not. Some, apparently, are used as is, i.e. the English term.