### PR TITLE
i18n: Activate all 275 unfinished German translations

### DIFF
--- a/i18n/de.ts
+++ b/i18n/de.ts
@@ -270,7 +270,7 @@
     <message>
         <location filename="../src/dialogs/batchdialog.ui" line="791"/>
         <source>Threads</source>
-        <translation type="unfinished">Threads</translation>
+        <translation>Threads</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.ui" line="805"/>
@@ -323,7 +323,7 @@
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="244"/>
         <source>At least one of the Rename / Convert options have to be selected.</source>
-        <translation type="unfinished">Mindestens eine der Umbenennen / Umwandeln Optionen muß ausgewählt werden.</translation>
+        <translation>Mindestens eine der Umbenennen / Umwandeln Optionen muß ausgewählt werden.</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="250"/>
@@ -364,17 +364,17 @@
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="477"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="508"/>
         <source>Cannot load image for preview.</source>
-        <translation type="unfinished">Bild kann nicht für Vorschau geladen werden.</translation>
+        <translation>Bild kann nicht für Vorschau geladen werden.</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="600"/>
         <source>Select Target Directory</source>
-        <translation type="unfinished">Zielverzeichnis auswählen</translation>
+        <translation>Zielverzeichnis auswählen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="862"/>
@@ -384,7 +384,7 @@
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="921"/>
         <source>Threads: %1/%2</source>
-        <translation type="unfinished">Threads: %1/%2</translation>
+        <translation>Threads: %1/%2</translation>
     </message>
 </context>
 <context>
@@ -392,33 +392,33 @@
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="1040"/>
         <source>input</source>
-        <translation type="unfinished">Eingabe</translation>
+        <translation>Eingabe</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="1045"/>
         <location filename="../src/dialogs/batchdialog.cpp" line="1053"/>
         <source>already exists</source>
-        <translation type="unfinished">existiert bereits</translation>
+        <translation>existiert bereits</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="1062"/>
         <source>cannot read</source>
-        <translation type="unfinished">kann nicht gelesen werden</translation>
+        <translation>kann nicht gelesen werden</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="1071"/>
         <source>over-crop</source>
-        <translation type="unfinished">Beschneidungsgrenzen überschritten</translation>
+        <translation>Beschneidungsgrenzen überschritten</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="1187"/>
         <source>resized to zero</source>
-        <translation type="unfinished">Größe auf 0 geändert</translation>
+        <translation>Größe auf 0 geändert</translation>
     </message>
     <message>
         <location filename="../src/dialogs/batchdialog.cpp" line="1200"/>
         <source>cannot write</source>
-        <translation type="unfinished">kann nicht schreiben</translation>
+        <translation>kann nicht schreiben</translation>
     </message>
 </context>
 <context>
@@ -555,7 +555,7 @@
     <message>
         <location filename="../src/effects/moduleCharcoal.h" line="36"/>
         <source>Charcoal</source>
-        <translation type="unfinished">Kohlezeichnung</translation>
+        <translation>Kohlezeichnung</translation>
     </message>
 </context>
 <context>
@@ -578,7 +578,7 @@
     <message>
         <location filename="../src/effects/moduleColorAdjust.cpp" line="40"/>
         <source>Exposure</source>
-        <translation type="unfinished">Belichtung</translation>
+        <translation>Belichtung</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleColorAdjust.cpp" line="41"/>
@@ -626,12 +626,12 @@
     <message>
         <location filename="../src/effects/moduleColorQuantization.cpp" line="38"/>
         <source>Web-safe colors</source>
-        <translation type="unfinished">Farben für Internetseitenverwendung</translation>
+        <translation>Farben für Internetseitenverwendung</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleColorQuantization.cpp" line="39"/>
         <source>Sorted colors</source>
-        <translation type="unfinished">Farbsortierung</translation>
+        <translation>Farbsortierung</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleColorQuantization.cpp" line="46"/>
@@ -646,12 +646,12 @@
     <message>
         <location filename="../src/effects/moduleColorQuantization.cpp" line="41"/>
         <source>None</source>
-        <translation type="unfinished">Keine</translation>
+        <translation>Keine</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleColorQuantization.h" line="40"/>
         <source>Color Quantization</source>
-        <translation type="unfinished">Farb-Quantisierung</translation>
+        <translation>Farb-Quantisierung</translation>
     </message>
 </context>
 <context>
@@ -708,7 +708,7 @@
     <message>
         <location filename="../src/effects/moduleHistEqual.h" line="36"/>
         <source>Histogram equalization</source>
-        <translation type="unfinished">Histogrammausgleich</translation>
+        <translation>Histogrammausgleich</translation>
     </message>
 </context>
 <context>
@@ -716,17 +716,17 @@
     <message>
         <location filename="../src/effects/moduleLocalColorCorrection.cpp" line="36"/>
         <source>Radius</source>
-        <translation type="unfinished">Radius</translation>
+        <translation>Radius</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleLocalColorCorrection.cpp" line="37"/>
         <source>Strength</source>
-        <translation type="unfinished">Stärke</translation>
+        <translation>Stärke</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleLocalColorCorrection.h" line="35"/>
         <source>Local Color Correction</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -747,7 +747,7 @@
     <message>
         <location filename="../src/effects/moduleNormalize.h" line="36"/>
         <source>Normalize</source>
-        <translation type="unfinished">Normalisieren</translation>
+        <translation>Normalisieren</translation>
     </message>
 </context>
 <context>
@@ -755,7 +755,7 @@
     <message>
         <location filename="../src/effects/moduleReduceNoise.h" line="36"/>
         <source>Reduce noise</source>
-        <translation type="unfinished">Rauschverminderung</translation>
+        <translation>Rauschverminderung</translation>
     </message>
 </context>
 <context>
@@ -763,7 +763,7 @@
     <message>
         <location filename="../src/effects/moduleSepia.h" line="36"/>
         <source>Sepia</source>
-        <translation type="unfinished">Sepia</translation>
+        <translation>Sepia</translation>
     </message>
 </context>
 <context>
@@ -771,12 +771,12 @@
     <message>
         <location filename="../src/effects/moduleSharpen.cpp" line="37"/>
         <source>Strength</source>
-        <translation type="unfinished">Stärke</translation>
+        <translation>Stärke</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSharpen.h" line="36"/>
         <source>Sharpen</source>
-        <translation type="unfinished">Schärfen</translation>
+        <translation>Schärfen</translation>
     </message>
 </context>
 <context>
@@ -784,7 +784,7 @@
     <message>
         <location filename="../src/effects/moduleSobel.h" line="36"/>
         <source>Sobel edge detector</source>
-        <translation type="unfinished">Sobel-Kantenerkennungsfilters</translation>
+        <translation>Sobel-Kantenerkennungsfilters</translation>
     </message>
 </context>
 <context>
@@ -792,12 +792,12 @@
     <message>
         <location filename="../src/effects/moduleSpread.cpp" line="46"/>
         <source>Spread</source>
-        <translation type="unfinished">Verteilung</translation>
+        <translation>Verteilung</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSpread.h" line="36"/>
         <source>Spread pixels</source>
-        <translation type="unfinished">Pixel verteilen</translation>
+        <translation>Pixel verteilen</translation>
     </message>
 </context>
 <context>
@@ -805,42 +805,42 @@
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="42"/>
         <source>RGB to</source>
-        <translation type="unfinished">RGB umwandeln in</translation>
+        <translation>RGB umwandeln in</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="36"/>
         <source>RGB</source>
-        <translation type="unfinished">RGB</translation>
+        <translation>RGB</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="37"/>
         <source>RBG</source>
-        <translation type="unfinished">RBG</translation>
+        <translation>RBG</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="38"/>
         <source>GRB</source>
-        <translation type="unfinished">GRB</translation>
+        <translation>GRB</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="39"/>
         <source>GBR</source>
-        <translation type="unfinished">GBR</translation>
+        <translation>GBR</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="40"/>
         <source>BRG</source>
-        <translation type="unfinished">BRG</translation>
+        <translation>BRG</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.cpp" line="41"/>
         <source>BGR</source>
-        <translation type="unfinished">BGR</translation>
+        <translation>BGR</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleSwapChannels.h" line="36"/>
         <source>Swap channels</source>
-        <translation type="unfinished">Kanäle tauschen</translation>
+        <translation>Kanäle tauschen</translation>
     </message>
 </context>
 <context>
@@ -848,7 +848,7 @@
     <message>
         <location filename="../src/effects/moduleTemplate.h" line="45"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -861,12 +861,12 @@
     <message>
         <location filename="../src/effects/moduleUnsharp.cpp" line="37"/>
         <source>Amount</source>
-        <translation type="unfinished">Stärke</translation>
+        <translation>Stärke</translation>
     </message>
     <message>
         <location filename="../src/effects/moduleUnsharp.h" line="36"/>
         <source>Unsharp</source>
-        <translation type="unfinished">Entschärfen</translation>
+        <translation>Entschärfen</translation>
     </message>
 </context>
 <context>
@@ -882,7 +882,7 @@
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="23"/>
         <source>External tools config</source>
-        <translation type="unfinished">Externe Werkzeuge</translation>
+        <translation>Externe Werkzeuge</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="44"/>
@@ -895,7 +895,7 @@
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="291"/>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="333"/>
         <source>BMP</source>
-        <translation type="unfinished">BMP</translation>
+        <translation>BMP</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="49"/>
@@ -908,7 +908,7 @@
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="296"/>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="338"/>
         <source>JPG</source>
-        <translation type="unfinished">JPG</translation>
+        <translation>JPG</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="54"/>
@@ -921,22 +921,22 @@
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="301"/>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="343"/>
         <source>PNG</source>
-        <translation type="unfinished">PNG</translation>
+        <translation>PNG</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="103"/>
         <source>File type</source>
-        <translation type="unfinished">Dateityp</translation>
+        <translation>Dateityp</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="154"/>
         <source>Shell</source>
-        <translation type="unfinished">Shell</translation>
+        <translation>Shell</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.ui" line="360"/>
         <source>Full path of the script</source>
-        <translation type="unfinished">Vollständiger Pfad des Skripts</translation>
+        <translation>Vollständiger Pfad des Skripts</translation>
     </message>
     <message>
         <location filename="../src/dialogs/exttoolconfigdialog.cpp" line="61"/>
@@ -956,7 +956,7 @@ Both files are deleted automatically.
 
 Example sh script (copy the image unaltered):
 </source>
-        <translation type="unfinished">Externe Werkzeuge sind Skripte, die 2 Argumente annehmen:
+        <translation>Externe Werkzeuge sind Skripte, die 2 Argumente annehmen:
 1) Verzeichnis für Eingabedatei
 2) Verzeichnis für Ausgabedatei
 Beide Verzeichnisse werden diesen Skripten bereitgestellt.
@@ -1009,12 +1009,12 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/io/moduleQt.cpp" line="123"/>
         <source>Optimized write</source>
-        <translation type="unfinished">Optimisiertes Schreiben</translation>
+        <translation>Optimisiertes Schreiben</translation>
     </message>
     <message>
         <location filename="../src/io/moduleQt.cpp" line="132"/>
         <source>Progressive scan</source>
-        <translation type="unfinished">Progressive Abtastung</translation>
+        <translation>Progressive Abtastung</translation>
     </message>
 </context>
 <context>
@@ -1042,32 +1042,32 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/io/moduleVips.cpp" line="232"/>
         <source>AOM</source>
-        <translation type="unfinished">AOM</translation>
+        <translation>AOM</translation>
     </message>
     <message>
         <location filename="../src/io/moduleVips.cpp" line="233"/>
         <source>RAV1E</source>
-        <translation type="unfinished">RAV1E</translation>
+        <translation>RAV1E</translation>
     </message>
     <message>
         <location filename="../src/io/moduleVips.cpp" line="234"/>
         <source>SVT</source>
-        <translation type="unfinished">SVT</translation>
+        <translation>SVT</translation>
     </message>
     <message>
         <location filename="../src/io/moduleVips.cpp" line="235"/>
         <source>x265</source>
-        <translation type="unfinished">x265</translation>
+        <translation>x265</translation>
     </message>
     <message>
         <location filename="../src/io/moduleVips.cpp" line="242"/>
         <source>Dithering</source>
-        <translation type="unfinished">Dithering / Fehlerdiffusion</translation>
+        <translation>Dithering / Fehlerdiffusion</translation>
     </message>
     <message>
         <location filename="../src/io/moduleVips.cpp" line="250"/>
         <source>Quantisation effort</source>
-        <translation type="unfinished">Quantisierungsaufwand</translation>
+        <translation>Quantisierungsaufwand</translation>
     </message>
 </context>
 <context>
@@ -1075,22 +1075,22 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/dialogs/infodialog.ui" line="17"/>
         <source>Info</source>
-        <translation type="unfinished">Information</translation>
+        <translation>Information</translation>
     </message>
     <message>
         <location filename="../src/dialogs/infodialog.cpp" line="36"/>
         <source>This functionality requires &apos;exiftool&apos; to be installed</source>
-        <translation type="unfinished">Für diese Funktion muß &apos;exiftool&apos;installiert sein</translation>
+        <translation>Für diese Funktion muß &apos;exiftool&apos;installiert sein</translation>
     </message>
     <message>
         <location filename="../src/dialogs/infodialog.cpp" line="46"/>
         <source>Tag</source>
-        <translation type="unfinished">Tag / Eintrag</translation>
+        <translation>Tag / Eintrag</translation>
     </message>
     <message>
         <location filename="../src/dialogs/infodialog.cpp" line="47"/>
         <source>Value</source>
-        <translation type="unfinished">Wert</translation>
+        <translation>Wert</translation>
     </message>
 </context>
 <context>
@@ -1103,17 +1103,17 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/dialogs/licensedialog.ui" line="35"/>
         <source>ClassicImageViewer</source>
-        <translation type="unfinished">ClassicImageViewer</translation>
+        <translation>ClassicImageViewer</translation>
     </message>
     <message>
         <location filename="../src/dialogs/licensedialog.ui" line="726"/>
         <source>GNOME icons</source>
-        <translation type="unfinished">GNOME-Symbole</translation>
+        <translation>GNOME-Symbole</translation>
     </message>
     <message>
         <location filename="../src/dialogs/licensedialog.ui" line="919"/>
         <source>QOI</source>
-        <translation type="unfinished">QOI</translation>
+        <translation>QOI</translation>
     </message>
 </context>
 <context>
@@ -1156,47 +1156,47 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="310"/>
         <source>&amp;Open</source>
-        <translation type="unfinished">&amp;Öffnen</translation>
+        <translation>&amp;Öffnen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="311"/>
         <source>&amp;Reload</source>
-        <translation type="unfinished">&amp;Neu laden</translation>
+        <translation>&amp;Neu laden</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="312"/>
         <source>Reopen in new app</source>
-        <translation type="unfinished">In neuem Fenster erneut öffnen</translation>
+        <translation>In neuem Fenster erneut öffnen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="313"/>
         <source>Open in &amp;external editor</source>
-        <translation type="unfinished">In &amp;externem Editor öffnen</translation>
+        <translation>In &amp;externem Editor öffnen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="315"/>
         <source>Recent &amp;files</source>
-        <translation type="unfinished">Zuletzt geöffnete &amp;Dateien</translation>
+        <translation>Zuletzt geöffnete &amp;Dateien</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="319"/>
         <source>&amp;Thumbnails</source>
-        <translation type="unfinished">&amp;Vorschaubilder</translation>
+        <translation>&amp;Vorschaubilder</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="320"/>
         <source>Slidesho&amp;w</source>
-        <translation type="unfinished">Dia&amp;schau</translation>
+        <translation>Dia&amp;schau</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="321"/>
         <source>&amp;Batch conversion</source>
-        <translation type="unfinished">&amp;Batch(Stapel)-Konvertierung / Umbenennung</translation>
+        <translation>&amp;Batch(Stapel)-Konvertierung / Umbenennung</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="323"/>
         <source>Re&amp;name file</source>
-        <translation type="unfinished">Datei &amp;umbennen</translation>
+        <translation>Datei &amp;umbenennen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="324"/>
@@ -1206,92 +1206,92 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="325"/>
         <source>&amp;Move file</source>
-        <translation type="unfinished">Datei &amp;verschieben</translation>
+        <translation>Datei &amp;verschieben</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="326"/>
         <source>&amp;Copy file</source>
-        <translation type="unfinished">Datei &amp;kopieren</translation>
+        <translation>Datei &amp;kopieren</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="327"/>
         <source>&amp;Delete file</source>
-        <translation type="unfinished">Datei &amp;löschen</translation>
+        <translation>Datei &amp;löschen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Sa&amp;ve</source>
-        <translation type="unfinished">S&amp;peichern</translation>
+        <translation>S&amp;peichern</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="330"/>
         <source>&amp;Save as</source>
-        <translation type="unfinished">&amp;Speichern unter</translation>
+        <translation>&amp;Speichern unter</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="331"/>
         <source>Save selection as</source>
-        <translation type="unfinished">Auswahl speichern als</translation>
+        <translation>Auswahl speichern als</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="332"/>
         <source>&amp;Print</source>
-        <translation type="unfinished">&amp;Drucken</translation>
+        <translation>&amp;Drucken</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="334"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Beenden</translation>
+        <translation>&amp;Beenden</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="337"/>
         <source>&amp;Undo</source>
-        <translation type="unfinished">R&amp;ückgängig</translation>
+        <translation>R&amp;ückgängig</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="338"/>
         <source>R&amp;edo</source>
-        <translation type="unfinished">Wi&amp;ederholen</translation>
+        <translation>Wi&amp;ederholen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="340"/>
         <source>Cust&amp;om selection</source>
-        <translation type="unfinished">&amp;Benutzerdefinierte Auswahl</translation>
+        <translation>&amp;Benutzerdefinierte Auswahl</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="341"/>
         <source>Cut &amp;selection</source>
-        <translation type="unfinished">Au&amp;swahl ausschneiden</translation>
+        <translation>Au&amp;swahl ausschneiden</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="342"/>
         <source>C&amp;rop selection</source>
-        <translation type="unfinished">Auswahl &amp;freistellen</translation>
+        <translation>Auswahl &amp;freistellen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="344"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;Kopieren</translation>
+        <translation>&amp;Kopieren</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="345"/>
         <source>&amp;Paste</source>
-        <translation type="unfinished">&amp;Einfügen</translation>
+        <translation>&amp;Einfügen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="346"/>
         <source>Paste to side</source>
-        <translation type="unfinished">Seitlich einfügen</translation>
+        <translation>Seitlich einfügen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="347"/>
         <source>Unloa&amp;d</source>
-        <translation type="unfinished">Entla&amp;den</translation>
+        <translation>Entla&amp;den</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="349"/>
         <source>C&amp;lear clipboard</source>
-        <translation type="unfinished">&amp;Zwischenablage leeren</translation>
+        <translation>&amp;Zwischenablage leeren</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="352"/>
@@ -1326,27 +1326,27 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="360"/>
         <source>Re&amp;size</source>
-        <translation type="unfinished">Grö&amp;ße ändern</translation>
+        <translation>Grö&amp;ße ändern</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="361"/>
         <source>Add &amp;border</source>
-        <translation type="unfinished">Ran&amp;d hinzufügen</translation>
+        <translation>Ran&amp;d hinzufügen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="362"/>
         <source>&amp;Pad to size</source>
-        <translation type="unfinished">&amp;Auffüllen</translation>
+        <translation>&amp;Auffüllen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="364"/>
         <source>I&amp;ncrease color depth</source>
-        <translation type="unfinished">Farbtiefe erhöhe&amp;n</translation>
+        <translation>Farbtiefe erhöhe&amp;n</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="365"/>
         <source>&amp;Decrease color depth</source>
-        <translation type="unfinished">Farbtiefe re&amp;duzieren</translation>
+        <translation>Farbtiefe re&amp;duzieren</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="367"/>
@@ -1356,7 +1356,7 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="369"/>
         <source>Adjust &amp;colors</source>
-        <translation type="unfinished">Farben &amp;anpassen</translation>
+        <translation>Farben &amp;anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="371"/>
@@ -1376,52 +1376,52 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="378"/>
         <source>External tool 1</source>
-        <translation type="unfinished">Externes Werkzeug 1</translation>
+        <translation>Externes Werkzeug 1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="379"/>
         <source>External tool 2</source>
-        <translation type="unfinished">Externes Werkzeug 2</translation>
+        <translation>Externes Werkzeug 2</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="380"/>
         <source>External tool 3</source>
-        <translation type="unfinished">Externes Werkzeug 3</translation>
+        <translation>Externes Werkzeug 3</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="381"/>
         <source>External tool 4</source>
-        <translation type="unfinished">Externes Werkzeug 4</translation>
+        <translation>Externes Werkzeug 4</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="382"/>
         <source>External tool 5</source>
-        <translation type="unfinished">Externes Werkzeug 5</translation>
+        <translation>Externes Werkzeug 5</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="383"/>
         <source>External tool 6</source>
-        <translation type="unfinished">Externes Werkzeug 6</translation>
+        <translation>Externes Werkzeug 6</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="384"/>
         <source>External tool 7</source>
-        <translation type="unfinished">Externes Werkzeug 7</translation>
+        <translation>Externes Werkzeug 7</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="385"/>
         <source>External tool 8</source>
-        <translation type="unfinished">Externes Werkzeug 8</translation>
+        <translation>Externes Werkzeug 8</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="386"/>
         <source>External tool 9</source>
-        <translation type="unfinished">Externes Werkzeug 9</translation>
+        <translation>Externes Werkzeug 9</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="389"/>
         <source>&amp;Properties</source>
-        <translation type="unfinished">&amp;Eigenschaften</translation>
+        <translation>&amp;Eigenschaften</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="393"/>
@@ -1441,57 +1441,57 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="397"/>
         <source>&amp;Display mode</source>
-        <translation type="unfinished">Anzeige-Optionen (Fenstermo&amp;dus)</translation>
+        <translation>Anzeige-Optionen (Fenstermo&amp;dus)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="398"/>
         <source>Fit window to images</source>
-        <translation type="unfinished">Fenstergröße an Bilder anpassen</translation>
+        <translation>Fenstergröße an Bilder anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="399"/>
         <source>Fit all images to window</source>
-        <translation type="unfinished">Alle Bilder an Fenstergröße anpassen</translation>
+        <translation>Alle Bilder an Fenstergröße anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="400"/>
         <source>Fit large images to window</source>
-        <translation type="unfinished">Große Bilder an Fenstergröße anpassen</translation>
+        <translation>Große Bilder an Fenstergröße anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="401"/>
         <source>Fit all images to desktop</source>
-        <translation type="unfinished">Alle Bilder an Schreibtisch anpassen</translation>
+        <translation>Alle Bilder an Schreibtisch anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="402"/>
         <source>Fit large images to desktop</source>
-        <translation type="unfinished">Große Bilder an Schreibtisch anpassen</translation>
+        <translation>Große Bilder an Schreibtisch anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="403"/>
         <source>Do not fit</source>
-        <translation type="unfinished">Nicht anpassen</translation>
+        <translation>Nicht anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="410"/>
         <source>Fi&amp;rst file in directory</source>
-        <translation type="unfinished">E&amp;rste Datei im Verzeichnis</translation>
+        <translation>E&amp;rste Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="413"/>
         <source>Zoom &amp;in</source>
-        <translation type="unfinished">Vergrößer&amp;n</translation>
+        <translation>Vergrößer&amp;n</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="415"/>
         <source>Zoom 1:1</source>
-        <translation type="unfinished">Originalgröße</translation>
+        <translation>Originalgröße</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="416"/>
         <source>&amp;Zoom levels</source>
-        <translation type="unfinished">&amp;Vergrößerungsstufen</translation>
+        <translation>&amp;Vergrößerungsstufen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="418"/>
@@ -1576,166 +1576,166 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
     <message>
         <location filename="../src/mainwindow.cpp" line="443"/>
         <source>First file in directory</source>
-        <translation type="unfinished">Erste Datei im Verzeichnis</translation>
+        <translation>Erste Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="444"/>
         <source>Last file in directory</source>
-        <translation type="unfinished">Letzte Datei im Verzeichnis</translation>
+        <translation>Letzte Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="445"/>
         <location filename="../src/mainwindow.cpp" line="447"/>
         <location filename="../src/mainwindow.cpp" line="449"/>
         <source>Previous file in directory</source>
-        <translation type="unfinished">Vorherige Datei im Verzeichnis</translation>
+        <translation>Vorherige Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="446"/>
         <location filename="../src/mainwindow.cpp" line="448"/>
         <location filename="../src/mainwindow.cpp" line="450"/>
         <source>Next file in directory</source>
-        <translation type="unfinished">Nächste Datei im Verzeichnis</translation>
+        <translation>Nächste Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="451"/>
         <source>Toggle selection all</source>
-        <translation type="unfinished">&quot;Alles auswählen&quot; ein-/ausschalten</translation>
+        <translation>&quot;Alles auswählen&quot; ein-/ausschalten</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="452"/>
         <source>Adjust left side of the selection</source>
-        <translation type="unfinished">Auswahl links anpassen</translation>
+        <translation>Auswahl links anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="453"/>
         <source>Adjust top side of the selection</source>
-        <translation type="unfinished">Auswahl oben anpassen</translation>
+        <translation>Auswahl oben anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="454"/>
         <source>Adjust right side of the selection</source>
-        <translation type="unfinished">Auswahl rechts anpassen</translation>
+        <translation>Auswahl rechts anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="455"/>
         <source>Adjust bottom side of the selection</source>
-        <translation type="unfinished">Auswahl unten anpassen</translation>
+        <translation>Auswahl unten anpassen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="456"/>
         <source>Move selection</source>
-        <translation type="unfinished">Auswahl verschieben</translation>
+        <translation>Auswahl verschieben</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1182"/>
         <source>Color Quantization</source>
-        <translation type="unfinished">Farbreduktion</translation>
+        <translation>Farbreduktion</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1278"/>
         <source>External tool %1 is not configured.</source>
-        <translation type="unfinished">Externes Werkzeug %1ist nicht konfiguriert.</translation>
+        <translation>Externes Werkzeug %1ist nicht konfiguriert.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1309"/>
         <source>Failed to save the script input file.</source>
-        <translation type="unfinished">Eingangsdatei des Skriptes konnte nicht gespeichert werden.</translation>
+        <translation>Eingangsdatei des Skriptes konnte nicht gespeichert werden.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>External tool %1 failed to start.</source>
-        <translation type="unfinished">Externes Werkzeug %1 konnte nicht gestartet werden.</translation>
+        <translation>Externes Werkzeug %1 konnte nicht gestartet werden.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1325"/>
         <source>External tool %1</source>
-        <translation type="unfinished">Externes Werkzeug %1</translation>
+        <translation>Externes Werkzeug %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1326"/>
         <source>The execution of the script is in progress...</source>
-        <translation type="unfinished">Skript wird ausgeführt...</translation>
+        <translation>Skript wird ausgeführt...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1348"/>
         <source>Failed to load the script output file.</source>
-        <translation type="unfinished">Ausgabedatei des Skriptes konnte nicht geladen werden.</translation>
+        <translation>Ausgabedatei des Skriptes konnte nicht geladen werden.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2029"/>
         <source>Indexing the current directory...</source>
-        <translation type="unfinished">Aktuelles Verzeichnis indexieren...</translation>
+        <translation>Aktuelles Verzeichnis indexieren...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2609"/>
         <source>Not configured</source>
-        <translation type="unfinished">Nicht konfiguriert</translation>
+        <translation>Nicht konfiguriert</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2692"/>
         <source>Save...</source>
-        <translation type="unfinished">Speichern...</translation>
+        <translation>Speichern...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="368"/>
         <source>Nega&amp;tive</source>
-        <translation type="unfinished">Nega&amp;tive</translation>
+        <translation>Nega&amp;tive</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="372"/>
         <source>Sh&amp;arpen</source>
-        <translation type="unfinished">Sch&amp;ärfen</translation>
+        <translation>Sch&amp;ärfen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="373"/>
         <source>&amp;Effects</source>
-        <translation type="unfinished">&amp;Effekte</translation>
+        <translation>&amp;Effekte</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="390"/>
         <source>&amp;Minimize</source>
-        <translation type="unfinished">&amp;Minimieren</translation>
+        <translation>&amp;Minimieren</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="406"/>
         <source>&amp;Full screen</source>
-        <translation type="unfinished">&amp;Vollbild</translation>
+        <translation>&amp;Vollbild</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="408"/>
         <source>&amp;Next file in directory</source>
-        <translation type="unfinished">&amp;Nächste Datei im Verzeichnis</translation>
+        <translation>&amp;Nächste Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="409"/>
         <source>&amp;Previous file in directory</source>
-        <translation type="unfinished">Vo&amp;rherige Datei im Verzeichnis</translation>
+        <translation>Vo&amp;rherige Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="411"/>
         <source>&amp;Last file in directory</source>
-        <translation type="unfinished">&amp;Letzte Datei im Verzeichnis</translation>
+        <translation>&amp;Letzte Datei im Verzeichnis</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="414"/>
         <source>Zoom &amp;out</source>
-        <translation type="unfinished">V&amp;erkleinern</translation>
+        <translation>V&amp;erkleinern</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="437"/>
         <source>&amp;License</source>
-        <translation type="unfinished">&amp;Lizenz</translation>
+        <translation>&amp;Lizenz</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="438"/>
         <source>&amp;Shortcuts</source>
-        <translation type="unfinished">Ta&amp;stenkürzel</translation>
+        <translation>Ta&amp;stenkürzel</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="439"/>
         <source>&amp;About</source>
-        <translation type="unfinished">&amp;Über</translation>
+        <translation>&amp;Über</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="647"/>
@@ -1757,113 +1757,113 @@ Beispiel-sh-Skript (das Bild unverändert kopieren):
         <location filename="../src/mainwindow.cpp" line="1348"/>
         <location filename="../src/mainwindow.cpp" line="2080"/>
         <source>Error</source>
-        <translation type="unfinished">Fehler</translation>
+        <translation>Fehler</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="647"/>
         <source>Cannot rename to empty filename.</source>
-        <translation type="unfinished">Kann nicht in leeren Dateinamen umbennen.</translation>
+        <translation>Kann nicht in leeren Dateinamen umbennen.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="662"/>
         <source>Failed to rename the file.
 Maybe the provided file name already exists.</source>
-        <translation type="unfinished">Umbennen der Datei fehlgeschlagen.
+        <translation>Umbennen der Datei fehlgeschlagen.
 Eventuell existiert bereits eine Datei mit dem angegebenen Dateinamen.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="684"/>
         <location filename="../src/mainwindow.cpp" line="723"/>
         <source>Target directory not set.</source>
-        <translation type="unfinished">Kein Zielverteichnis angebeben.</translation>
+        <translation>Kein Zielverteichnis angebeben.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="688"/>
         <location filename="../src/mainwindow.cpp" line="727"/>
         <source>Target directory cannot be the current one.</source>
-        <translation type="unfinished">Zielverzeichnis darf nicht das aktuell verwendete sein.</translation>
+        <translation>Zielverzeichnis darf nicht das aktuell verwendete sein.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="773"/>
         <source>Failed to move %1 to trash.</source>
-        <translation type="unfinished">Konnte %1 nicht in den Papierkorb verschieben.</translation>
+        <translation>Konnte %1 nicht in den Papierkorb verschieben.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="777"/>
         <source>Failed to move %1 to trash.
 Currently only &apos;gio&apos; and &apos;kioclient5&apos; based operation supported.</source>
-        <translation type="unfinished">Konnte %1 nicht in den Papierkorb verschieben.
+        <translation>Konnte %1 nicht in den Papierkorb verschieben.
 Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operationen unterstützt.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="817"/>
         <location filename="../src/mainwindow.cpp" line="844"/>
         <source>Save to %1 failed.</source>
-        <translation type="unfinished">Speichern nach %1 fehlgeschlagen.</translation>
+        <translation>Speichern nach %1 fehlgeschlagen.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="875"/>
         <source>Printer initialization failed.</source>
-        <translation type="unfinished">Druckereinrichtung fehlgeschlagen.</translation>
+        <translation>Druckereinrichtung fehlgeschlagen.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="954"/>
         <location filename="../src/mainwindow.cpp" line="988"/>
         <source>QClipboard error.</source>
-        <translation type="unfinished">Zwischenablagefehler (Qt).</translation>
+        <translation>Zwischenablagefehler (Qt).</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="962"/>
         <source>Clipboard %1</source>
-        <translation type="unfinished">Zwischenablage %1</translation>
+        <translation>Zwischenablage %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1675"/>
         <location filename="../src/mainwindow.cpp" line="1676"/>
         <source>Trying to hack the clipboard...</source>
-        <translation type="unfinished">Versuche Zwischenablage zu hacken...</translation>
+        <translation>Versuche Zwischenablage zu hacken...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1721"/>
         <location filename="../src/mainwindow.cpp" line="1934"/>
         <source>No file loaded</source>
-        <translation type="unfinished">Keine Datei geladen</translation>
+        <translation>Keine Datei geladen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1745"/>
         <location filename="../src/mainwindow.cpp" line="1935"/>
         <source>No selection</source>
-        <translation type="unfinished">Keine Auswahl</translation>
+        <translation>Keine Auswahl</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1749"/>
         <source>Selection: %1x%2 at (%3,%4)</source>
-        <translation type="unfinished">Auswahl: %1x%2 at (%3,%4)</translation>
+        <translation>Auswahl: %1x%2 at (%3,%4)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="1773"/>
         <source>Pixel: %1 at (%2,%3)</source>
-        <translation type="unfinished">Pixel: %1 at (%2,%3)</translation>
+        <translation>Pixel: %1 at (%2,%3)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2080"/>
         <source>Can not open %1</source>
-        <translation type="unfinished">%1 kann nicht geöffnet werden</translation>
+        <translation>%1 kann nicht geöffnet werden</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2577"/>
         <source>&amp;Clear recent files</source>
-        <translation type="unfinished">Liste der zuletzt &amp;geöffneten Dateien löschen</translation>
+        <translation>Liste der zuletzt &amp;geöffneten Dateien löschen</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2635"/>
         <source>All supported images</source>
-        <translation type="unfinished">Alle unterstützten Bilder</translation>
+        <translation>Alle unterstützten Bilder</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2648"/>
         <source>All files</source>
-        <translation type="unfinished">Alle Dateien</translation>
+        <translation>Alle Dateien</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="2651"/>
@@ -1876,12 +1876,12 @@ Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operatio
     <message>
         <location filename="../src/dialogs/padtosizedialog.ui" line="17"/>
         <source>Pad to size</source>
-        <translation type="unfinished">Farb-Rahmen hinzufügen / Leinwandgröße ändern</translation>
+        <translation>Farb-Rahmen hinzufügen / Leinwandgröße ändern</translation>
     </message>
     <message>
         <location filename="../src/dialogs/padtosizedialog.ui" line="64"/>
         <source>New size:</source>
-        <translation type="unfinished">Neue Größe:</translation>
+        <translation>Neue Größe:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/padtosizedialog.ui" line="78"/>
@@ -1891,7 +1891,7 @@ Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operatio
     <message>
         <location filename="../src/dialogs/padtosizedialog.ui" line="92"/>
         <source>Aspect ratio:</source>
-        <translation type="unfinished">Seitenverhältnis:</translation>
+        <translation>Seitenverhältnis:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/padtosizedialog.ui" line="119"/>
@@ -1906,7 +1906,7 @@ Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operatio
     <message>
         <location filename="../src/dialogs/padtosizedialog.ui" line="163"/>
         <source>Direction:</source>
-        <translation type="unfinished">Ausrichtung:</translation>
+        <translation>Ausrichtung:</translation>
     </message>
 </context>
 <context>
@@ -1927,78 +1927,78 @@ Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operatio
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="23"/>
         <source>Preferences</source>
-        <translation type="unfinished">Einstellungen</translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="35"/>
         <source>General</source>
-        <translation type="unfinished">Allgemein</translation>
+        <translation>Allgemein</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="97"/>
         <source>Name</source>
-        <translation type="unfinished">Nach Name</translation>
+        <translation>Nach Name</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="102"/>
         <source>Name (reversed)</source>
-        <translation type="unfinished">Nach Name (umgekehrt)</translation>
+        <translation>Nach Name (umgekehrt)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="107"/>
         <source>Time</source>
-        <translation type="unfinished">Nach Zeit</translation>
+        <translation>Nach Zeit</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="112"/>
         <source>Time (reversed)</source>
-        <translation type="unfinished">Nach Zeit (umgekehrt)</translation>
+        <translation>Nach Zeit (umgekehrt)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="74"/>
         <source>System</source>
-        <translation type="unfinished">System</translation>
+        <translation>System</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="161"/>
         <source>Start maximized</source>
-        <translation type="unfinished">Maximiert starten</translation>
+        <translation>Maximiert starten</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="412"/>
         <source>Display</source>
-        <translation type="unfinished">Anzeige</translation>
+        <translation>Anzeige</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="506"/>
         <location filename="../src/dialogs/preferencesdialog.ui" line="624"/>
         <source>Display mode:</source>
-        <translation type="unfinished">Anzeige-Optionen (Fenstermodus):</translation>
+        <translation>Anzeige-Optionen (Fenstermodus):</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="425"/>
         <source>Fit window to images</source>
-        <translation type="unfinished">Fenstergröße an Bilder anpassen</translation>
+        <translation>Fenstergröße an Bilder anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="430"/>
         <source>Fit all images to window</source>
-        <translation type="unfinished">Alle Bilder an Fenstergröße anpassen</translation>
+        <translation>Alle Bilder an Fenstergröße anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="435"/>
         <source>Fit large images to window</source>
-        <translation type="unfinished">Große Bilder an Fenstergröße anpassen</translation>
+        <translation>Große Bilder an Fenstergröße anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="181"/>
         <source>Zoom delta:</source>
-        <translation type="unfinished">Zoom-Faktor:</translation>
+        <translation>Zoom-Faktor:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="140"/>
         <source>Locale:</source>
-        <translation type="unfinished">Spracheinstellung:</translation>
+        <translation>Spracheinstellung:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="147"/>
@@ -2014,304 +2014,304 @@ Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operatio
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="60"/>
         <source>(if disabled, the exit could take a long time)</source>
-        <translation type="unfinished">(wenn deaktiviert kann das nächste Schließen des Programmfensters länger dauern)</translation>
+        <translation>(wenn deaktiviert kann das nächste Schließen des Programmfensters länger dauern)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="198"/>
         <source>File order:</source>
-        <translation type="unfinished">Dateisortierung:</translation>
+        <translation>Dateisortierung:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="53"/>
         <source>Loop directory</source>
-        <translation type="unfinished">Verzeichnisschleife</translation>
+        <translation>Verzeichnisschleife</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="472"/>
         <source>Display background:</source>
-        <translation type="unfinished">Anzeige-Hintergrund:</translation>
+        <translation>Anzeige-Hintergrund:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="219"/>
         <source>Reverse mouse wheel</source>
-        <translation type="unfinished">Mausradrichtung umkehren</translation>
+        <translation>Mausradrichtung umkehren</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="83"/>
         <source>XOR frame</source>
-        <translation type="unfinished">XOR-Rahmen</translation>
+        <translation>XOR-Rahmen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="88"/>
         <source>Highlight (fast)</source>
-        <translation type="unfinished">Hervorheben (schnell)</translation>
+        <translation>Hervorheben (schnell)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="212"/>
         <source>(not applied on the current image)</source>
-        <translation type="unfinished">(wird nicht auf aktuelles Bild angewendet)</translation>
+        <translation>(wird nicht auf aktuelles Bild angewendet)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="465"/>
         <source>(of white)</source>
-        <translation type="unfinished">(bezogen auf Weiß)</translation>
+        <translation>(bezogen auf Weiß)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="205"/>
         <source>Selection tool:</source>
-        <translation type="unfinished">Auswahlwerkzeug:</translation>
+        <translation>Auswahlwerkzeug:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="513"/>
         <source>Display quality:</source>
-        <translation type="unfinished">Darstellungsqualität:</translation>
+        <translation>Darstellungsqualität:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="458"/>
         <source>Fit window to images when zoomed</source>
-        <translation type="unfinished">Fenstergröße bei Vergrößerung an Bilder anpassen</translation>
+        <translation>Fenstergröße bei Vergrößerung an Bilder anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="120"/>
         <source>Enable Toolbar shrinking</source>
-        <translation type="unfinished">Verkleinerung der Werkzeugleiste aktivieren</translation>
+        <translation>Verkleinerung der Werkzeugleiste aktivieren</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="521"/>
         <source>Fast</source>
-        <translation type="unfinished">Schnell</translation>
+        <translation>Schnell</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="526"/>
         <source>Quality</source>
-        <translation type="unfinished">Qualität</translation>
+        <translation>Qualität</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="534"/>
         <source>(reduces downscaling aliasing effects)</source>
-        <translation type="unfinished">(reduziert Treppen-Effekt beim Verkleinern)</translation>
+        <translation>(reduziert Treppen-Effekt beim Verkleinern)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="440"/>
         <source>Do not fit</source>
-        <translation type="unfinished">Nicht anpassen</translation>
+        <translation>Nicht anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="445"/>
         <source>Fit images to desktop</source>
-        <translation type="unfinished">Bilder an Schreibtisch anpassen</translation>
+        <translation>Bilder an Schreibtisch anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="450"/>
         <source>Fit large images to desktop</source>
-        <translation type="unfinished">Große Bilder an Schreibtisch anpassen</translation>
+        <translation>Große Bilder an Schreibtisch anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="154"/>
         <source>Start fullscreen (if image is loaded on startup)</source>
-        <translation type="unfinished">Im Vollbildmodus starten (wenn Bild beim Starten geöffnet wird)</translation>
+        <translation>Im Vollbildmodus starten (wenn Bild beim Starten geöffnet wird)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="226"/>
         <source>Clear Recent files on exit</source>
-        <translation type="unfinished">Liste der zuletzt geöffneten Dateien beim Beenden löschen</translation>
+        <translation>Liste der zuletzt geöffneten Dateien beim Beenden löschen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="250"/>
         <source>Performance</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="256"/>
         <source>Internal operations</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="550"/>
         <source>Fullscreen</source>
-        <translation type="unfinished">Vollbild</translation>
+        <translation>Vollbild</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="556"/>
         <source>Indicator font size:</source>
-        <translation type="unfinished">Anzeige-Schriftgöße:</translation>
+        <translation>Anzeige-Schriftgöße:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="563"/>
         <source>Enable file index indicator</source>
-        <translation type="unfinished">Datei-Index-anzeigen</translation>
+        <translation>Datei-Index-anzeigen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="571"/>
         <source>Dark gray</source>
-        <translation type="unfinished">Dunkelgrau</translation>
+        <translation>Dunkelgrau</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="576"/>
         <source>Gray</source>
-        <translation type="unfinished">Grau</translation>
+        <translation>Grau</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="581"/>
         <source>Light gray</source>
-        <translation type="unfinished">Hellgrau</translation>
+        <translation>Hellgrau</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="586"/>
         <source>White</source>
-        <translation type="unfinished">Weiß</translation>
+        <translation>Weiß</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="591"/>
         <source>Dark red</source>
-        <translation type="unfinished">Dunkelrot</translation>
+        <translation>Dunkelrot</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="596"/>
         <source>Red</source>
-        <translation type="unfinished">Rot</translation>
+        <translation>Rot</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="601"/>
         <source>Dark green</source>
-        <translation type="unfinished">Dunkelgrün</translation>
+        <translation>Dunkelgrün</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="606"/>
         <source>Green</source>
-        <translation type="unfinished">Grün</translation>
+        <translation>Grün</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="611"/>
         <source>Dark Blue</source>
-        <translation type="unfinished">Dunkelblau</translation>
+        <translation>Dunkelblau</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="616"/>
         <source>Blue</source>
-        <translation type="unfinished">Blau</translation>
+        <translation>Blau</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="632"/>
         <source>Fit all images to display</source>
-        <translation type="unfinished">Alle Bilder an Anzeige anpassen</translation>
+        <translation>Alle Bilder an Anzeige anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="637"/>
         <source>Fit large images to display</source>
-        <translation type="unfinished">Große Bilder an Anzeige anpassen</translation>
+        <translation>Große Bilder an Anzeige anpassen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="645"/>
         <source>Enable file name indicator</source>
-        <translation type="unfinished">Dateiname anzeigen</translation>
+        <translation>Dateiname anzeigen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="652"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="672"/>
         <source>Hide cursor</source>
-        <translation type="unfinished">Mauszeiger verbergen</translation>
+        <translation>Mauszeiger verbergen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="689"/>
         <source>Indicator color:</source>
-        <translation type="unfinished">Anzeige-Farbe:</translation>
+        <translation>Anzeige-Farbe:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="699"/>
         <source>Indicator font:</source>
-        <translation type="unfinished">Anzeige-Schrift:</translation>
+        <translation>Anzeige-Schrift:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="857"/>
         <source>External editors</source>
-        <translation type="unfinished">Externe Bearbeitungsprogramme</translation>
+        <translation>Externe Bearbeitungsprogramme</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="874"/>
         <source>Editor 4</source>
-        <translation type="unfinished">Programm 4</translation>
+        <translation>Programm 4</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="884"/>
         <source>Editor 1</source>
-        <translation type="unfinished">Programm 1</translation>
+        <translation>Programm 1</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="891"/>
         <source>Editor 3</source>
-        <translation type="unfinished">Programm 3</translation>
+        <translation>Programm 3</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="907"/>
         <source>Editor 2</source>
-        <translation type="unfinished">Programm 2</translation>
+        <translation>Programm 2</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="917"/>
         <source>Command (full path)</source>
-        <translation type="unfinished">Befehl (vollständiger Pfad)</translation>
+        <translation>Befehl (vollständiger Pfad)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="924"/>
         <source>Optional argument(s separated by semicolons)</source>
-        <translation type="unfinished">Optionale Argumente (&quot;;&quot; als Trennzeichen)</translation>
+        <translation>Optionale Argumente (&quot;;&quot; als Trennzeichen)</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="947"/>
         <source>File formats</source>
-        <translation type="unfinished">Dateiformate</translation>
+        <translation>Dateiformate</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="955"/>
         <source>IO modules:</source>
-        <translation type="unfinished">IO-Module:</translation>
+        <translation>IO-Module:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="335"/>
         <source>Undo stack</source>
-        <translation type="unfinished">Rückgängig-Stapel</translation>
+        <translation>Rückgängig-Stapel</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="351"/>
         <source>Memory limit:</source>
-        <translation type="unfinished">Speicherlimit:</translation>
+        <translation>Speicherlimit:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="358"/>
         <source>Minimum number of steps:</source>
-        <translation type="unfinished">Mindestanzahl an Schritten:</translation>
+        <translation>Mindestanzahl an Schritten:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="388"/>
         <source>MB</source>
-        <translation type="unfinished">MB</translation>
+        <translation>MB</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="723"/>
         <source>Thumbnails</source>
-        <translation type="unfinished">Vorschaubilder</translation>
+        <translation>Vorschaubilder</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="762"/>
         <source>Cache size:</source>
-        <translation type="unfinished">Cache-Größe:</translation>
+        <translation>Cache-Größe:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="306"/>
         <location filename="../src/dialogs/preferencesdialog.ui" line="769"/>
         <source>Multithreading:</source>
-        <translation type="unfinished">Multithreading:</translation>
+        <translation>Multithreading:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="263"/>
         <location filename="../src/dialogs/preferencesdialog.ui" line="777"/>
         <source>Auto</source>
-        <translation type="unfinished">Automatisch</translation>
+        <translation>Automatisch</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="268"/>
@@ -2358,69 +2358,69 @@ Derzeit werden nur &apos;gio&apos;- und &apos;kioclient5&apos;-basierte Operatio
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="833"/>
         <source>Preloading</source>
-        <translation type="unfinished">Laden der Anfangsgrößen</translation>
+        <translation>Laden der Anfangsgrößen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.ui" line="755"/>
         <source>Scroll speed:</source>
-        <translation type="unfinished">Bildlauf-Geschwindigkeit:</translation>
+        <translation>Bildlauf-Geschwindigkeit:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="132"/>
         <source>Restore defaults</source>
-        <translation type="unfinished">Standardeinstellungen wiederherstellen</translation>
+        <translation>Standardeinstellungen wiederherstellen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="132"/>
         <source>Do you really want to clear and restore all settings to the default?
 These includes previous files, effect parameter and more...
 The application will exit.</source>
-        <translation type="unfinished">Möchten Sie die Einstellungen wirklich löschen und die Standardeinstellungen wiederherstellen?
+        <translation>Möchten Sie die Einstellungen wirklich löschen und die Standardeinstellungen wiederherstellen?
 Dies betrifft auch &quot;zuletzt göffnete Dateien, Effekt-Einstellungen und mehr...
 Das Programm wird dann beendet.</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="265"/>
         <source>Extension</source>
-        <translation type="unfinished">Erweiterung</translation>
+        <translation>Erweiterung</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="265"/>
         <source>Open</source>
-        <translation type="unfinished">Öffnen</translation>
+        <translation>Öffnen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="265"/>
         <source>Thumbnail</source>
-        <translation type="unfinished">Vorschaubild</translation>
+        <translation>Vorschaubild</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="265"/>
         <source>Save</source>
-        <translation type="unfinished">Speichern</translation>
+        <translation>Speichern</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="280"/>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="281"/>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="282"/>
         <source>Toggle</source>
-        <translation type="unfinished">De-/Aktivieren</translation>
+        <translation>De-/Aktivieren</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="316"/>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="317"/>
         <source>additional extensions, use semicolon as separator</source>
-        <translation type="unfinished">zusätzliche Erweiterungen, zum Trennen &quot;;&quot; verwenden</translation>
+        <translation>zusätzliche Erweiterungen, zum Trennen &quot;;&quot; verwenden</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="319"/>
         <source>Try to open:</source>
-        <translation type="unfinished">Versuche zu öffnen:</translation>
+        <translation>Versuche zu öffnen:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/preferencesdialog.cpp" line="325"/>
         <source>Try to open unlisted formats</source>
-        <translation type="unfinished">Versuche nicht aufgeführte Formate zu öffnen</translation>
+        <translation>Versuche nicht aufgeführte Formate zu öffnen</translation>
     </message>
 </context>
 <context>
@@ -2490,33 +2490,33 @@ Das Programm wird dann beendet.</translation>
     <message>
         <location filename="../src/lib/resizer.cpp" line="122"/>
         <source>Nearest Neighbor</source>
-        <translation type="unfinished">Nächster-Nachbar-Interpolation (nearest neighbor)</translation>
+        <translation>Nächster-Nachbar-Interpolation (nearest neighbor)</translation>
     </message>
     <message>
         <location filename="../src/lib/resizer.cpp" line="123"/>
         <source>Bilinear</source>
-        <translation type="unfinished">Bilineare Interpolation (bilinear)</translation>
+        <translation>Bilineare Interpolation (bilinear)</translation>
     </message>
     <message>
         <location filename="../src/lib/resizer.cpp" line="125"/>
         <source>Bicubic (Catmull-Rom)</source>
-        <translation type="unfinished">Bikubische Interpolation (bicubic) (Catmull-Rom)</translation>
+        <translation>Bikubische Interpolation (bicubic) (Catmull-Rom)</translation>
     </message>
     <message>
         <location filename="../src/lib/resizer.cpp" line="126"/>
         <source>Bicubic (Mitchell-Netravali)</source>
-        <translation type="unfinished">Bikubische Interpolation (bicubic) (Mitchell-Netravali)</translation>
+        <translation>Bikubische Interpolation (bicubic) (Mitchell-Netravali)</translation>
     </message>
     <message>
         <location filename="../src/lib/resizer.cpp" line="127"/>
         <location filename="../src/lib/resizer.cpp" line="130"/>
         <source>Lanczos</source>
-        <translation type="unfinished">Lanczos Interpolation</translation>
+        <translation>Lanczos Interpolation</translation>
     </message>
     <message>
         <location filename="../src/lib/resizer.cpp" line="129"/>
         <source>Bicubic</source>
-        <translation type="unfinished">Bikubische Interpolation (bicubic)</translation>
+        <translation>Bikubische Interpolation (bicubic)</translation>
     </message>
 </context>
 <context>
@@ -2524,12 +2524,12 @@ Das Programm wird dann beendet.</translation>
     <message>
         <location filename="../src/dialogs/rotatedialog.ui" line="17"/>
         <source>Rotate</source>
-        <translation type="unfinished">Drehen</translation>
+        <translation>Drehen</translation>
     </message>
     <message>
         <location filename="../src/dialogs/rotatedialog.ui" line="114"/>
         <source>Fill color</source>
-        <translation type="unfinished">Füllfarbe</translation>
+        <translation>Füllfarbe</translation>
     </message>
 </context>
 <context>
@@ -2537,7 +2537,7 @@ Das Programm wird dann beendet.</translation>
     <message>
         <location filename="../src/widgets/savefiledialog.cpp" line="159"/>
         <source>Save these settings</source>
-        <translation type="unfinished">Diese Einstellungen speichern</translation>
+        <translation>Diese Einstellungen speichern</translation>
     </message>
 </context>
 <context>
@@ -2545,17 +2545,17 @@ Das Programm wird dann beendet.</translation>
     <message>
         <location filename="../src/dialogs/shortcutsdialog.ui" line="17"/>
         <source>Shortcuts</source>
-        <translation type="unfinished">Tastaturkürzel</translation>
+        <translation>Tastaturkürzel</translation>
     </message>
     <message>
         <location filename="../src/dialogs/shortcutsdialog.cpp" line="31"/>
         <source>Shortcut</source>
-        <translation type="unfinished">Tastaturkürzel</translation>
+        <translation>Tastaturkürzel</translation>
     </message>
     <message>
         <location filename="../src/dialogs/shortcutsdialog.cpp" line="32"/>
         <source>Action</source>
-        <translation type="unfinished">Aktion</translation>
+        <translation>Aktion</translation>
     </message>
 </context>
 <context>
@@ -2609,12 +2609,12 @@ Das Programm wird dann beendet.</translation>
     <message>
         <location filename="../src/dialogs/thumbnaildialog.ui" line="17"/>
         <source>Thumbnail</source>
-        <translation type="unfinished">Vorschaubild</translation>
+        <translation>Vorschaubild</translation>
     </message>
     <message>
         <location filename="../src/dialogs/thumbnaildialog.ui" line="57"/>
         <source>Size:</source>
-        <translation type="unfinished">Größe:</translation>
+        <translation>Größe:</translation>
     </message>
     <message>
         <location filename="../src/dialogs/thumbnaildialog.ui" line="65"/>


### PR DESCRIPTION
Remove type="unfinished" attribute from all translated strings to make them visible in the UI. Fix typo: "umbennen" -> "umbenennen".

Translation completeness: 476/476 (100%)