### PR TITLE
Preserve crop region between images; fix dock/tray icon

### DIFF
--- a/src/dialogs/customselectiondialog.cpp
+++ b/src/dialogs/customselectiondialog.cpp
@@ -277,18 +277,15 @@ QRect CustomSelectionDialog::getSelection()
 
 void CustomSelectionDialog::savePreferences()
 {
-	if (inputSelection.isNull())
+	Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "x", ui.spinBoxX->value());
+	Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "y", ui.spinBoxY->value());
+	Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "width", ui.spinBoxWidth->value());
+	Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "height", ui.spinBoxHeight->value());
+	if (ui.checkBoxAR->isChecked())
 	{
-		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "x", ui.spinBoxX->value());
-		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "y", ui.spinBoxY->value());
-		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "width", ui.spinBoxWidth->value());
-		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "height", ui.spinBoxHeight->value());
-		if (ui.checkBoxAR->isChecked())
-		{
-			Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "widthRatio", ui.doubleSpinBoxWidthRatio->value());
-			Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "heightRatio", ui.doubleSpinBoxHeightRatio->value());
-		}
-		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "lockAR", ui.checkBoxAR->isChecked());
+		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "widthRatio", ui.doubleSpinBoxWidthRatio->value());
+		Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "heightRatio", ui.doubleSpinBoxHeightRatio->value());
 	}
+	Globals::prefs->storeSpecificParameter("CustomSelectionDialog", "lockAR", ui.checkBoxAR->isChecked());
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,7 @@ int main(int argc, char *argv[])
 	QApplication app(argc, argv);
 	app.setApplicationName("ClassicImageViewer");
 	app.setApplicationVersion(CIV_VERSION);
+	app.setDesktopFileName("io.github.classicimageviewer.ClassicImageViewer");
 	
 	// Prefs
 	QString configDirAbsolutePath;


### PR DESCRIPTION
## Summary
- Modified the Shift+C crop config dialog to preserve the crop region configuration between images (previously whenever the image was changed or cropped, the config was reset)
- Declared the program icon so that it appears correctly in the app tray and dock in Ubuntu

## Test plan
- [x] Drag-select a crop region, Shift+C, confirm with OK, crop (Ctrl+Y) or open a different image, press Shift+C again with no new selection — region is recalled and re-applied to the canvas
- [x] `make install` then relaunch — app icon now shows correctly in the Ubuntu dock/app switcher